### PR TITLE
Enhance password prompts and recent paste list

### DIFF
--- a/pages/password_prompt.php
+++ b/pages/password_prompt.php
@@ -50,6 +50,9 @@ include '../includes/header.php';
                     <?php endif; ?>
                     <form method="post" id="passwordForm">
                         <input type="hidden" name="id" value="<?php echo htmlspecialchars($pasteId); ?>">
+                        <div class="alert alert-info text-light bg-opacity-50 rounded shadow-sm">
+                            🔒 You are trying to view a password-protected paste. A password is required to proceed.
+                        </div>
                         <div class="mb-3">
                             <label for="password" class="form-label">Password</label>
                             <input type="password" name="password" id="password" class="form-control" required autofocus>

--- a/pages/recent.php
+++ b/pages/recent.php
@@ -18,7 +18,7 @@ try {
     $totalPastes = $stmt->fetchColumn();
     
     $stmt = $pdo->prepare("
-        SELECT id, title, language, created_at, views
+        SELECT id, title, language, created_at, views, password
         FROM pastes 
         WHERE visibility = 'public' AND (expire_time IS NULL OR expire_time > ?)
         ORDER BY created_at DESC 
@@ -107,6 +107,9 @@ include '../includes/header.php';
             <a href="view.php?id=<?php echo htmlspecialchars($paste['id']); ?>" class="paste-card paste-card-link">
                 <p class="paste-language"><?php echo htmlspecialchars($paste['language']); ?></p>
                 <div class="paste-title">
+                    <?php if (!empty($paste['password'])): ?>
+                        <i class="bi bi-lock-fill text-warning me-1" title="Password Protected"></i>
+                    <?php endif; ?>
                     <?php echo htmlspecialchars($paste['title'] ?: 'Untitled Paste'); ?>
                 </div>
                 <p class="paste-time"><?php echo $timeAgo; ?></p>


### PR DESCRIPTION
## Summary
- show password requirement message above the password field
- indicate protected pastes in recent list with lock icon

## Testing
- `php -l pages/password_prompt.php` *(fails: `php: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68620fd5deac8321a3fb6729d2f20673