### PR TITLE
Add lock icon indicator on recent paste listings

### DIFF
--- a/pages/recent.php
+++ b/pages/recent.php
@@ -107,10 +107,10 @@ include '../includes/header.php';
             <a href="view.php?id=<?php echo htmlspecialchars($paste['id']); ?>" class="paste-card paste-card-link">
                 <p class="paste-language"><?php echo htmlspecialchars($paste['language']); ?></p>
                 <div class="paste-title">
-                    <?php if (!empty($paste['password'])): ?>
-                        <i class="bi bi-lock-fill text-warning me-1" title="Password Protected"></i>
-                    <?php endif; ?>
                     <?php echo htmlspecialchars($paste['title'] ?: 'Untitled Paste'); ?>
+                    <?php if (!empty($paste['password'])): ?>
+                        <i class="fa fa-lock text-muted ms-2" title="Password Protected"></i>
+                    <?php endif; ?>
                 </div>
                 <p class="paste-time"><?php echo $timeAgo; ?></p>
             </a>


### PR DESCRIPTION
## Summary
- show a lock icon on password-protected pastes in `pages/recent.php`

## Testing
- `php` not installed, so no syntax check executed

------
https://chatgpt.com/codex/tasks/task_e_68621344ea18832188c60610b8063393