### PR TITLE
Improve language selection with Select2

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -21,6 +21,9 @@
 
     <!-- jQuery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+
+    <!-- Select2 JS -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/includes/header.php
+++ b/includes/header.php
@@ -18,6 +18,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.cells.min.js"></script>
     
+    <!-- Select2 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/assets/css/style.css">
 </head>

--- a/pages/create.php
+++ b/pages/create.php
@@ -1004,6 +1004,14 @@ document.addEventListener('click', function(e) {
 document.addEventListener('DOMContentLoaded', function() {
     updateCharCount();
 });
+
+// Initialize Select2 for language selector
+$(document).ready(function() {
+    $('#language').select2({
+        placeholder: 'Select a language',
+        allowClear: true
+    });
+});
 </script>
 
 <?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add Select2 CSS and JS to the layout
- enable Select2 autocomplete on the language dropdown in create page

## Testing
- `php -l includes/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862315a1be483218ff4c4d27e4876c4