### PR TITLE
Fix recent pastes filter

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -188,6 +188,8 @@ function getRecentPastes($limit = 10) {
             SELECT id, title, language, created_at, views
             FROM pastes 
             WHERE is_public = 1 
+            AND visibility = 'public'
+            AND burn_after_read = 0
             AND (expire_time IS NULL OR expire_time > ?)
             AND (burned IS NULL OR burned = 0)
             ORDER BY created_at DESC 


### PR DESCRIPTION
## Summary
- filter burn after read and unlisted pastes from recent list

## Testing
- `php -l includes/db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e68c225c8321bd8b685cc155ed7a