### PR TITLE
Hide Load Templates button

### DIFF
--- a/pages/create.php
+++ b/pages/create.php
@@ -125,9 +125,9 @@ include '../includes/header.php';
                             <i class="fas fa-plus me-2"></i>Create Paste
                         </h4>
                         <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-light btn-sm" id="loadTemplateBtn">
-                                <i class="fas fa-file-code me-1"></i><span class="d-none d-sm-inline">Load </span>Template
-                            </button>
+                            <!-- <button type="button" class="btn btn-outline-light btn-sm" id="loadTemplateBtn"> -->
+                            <!--     <i class="fas fa-file-code me-1"></i><span class="d-none d-sm-inline">Load </span>Template -->
+                            <!-- </button> -->
                             <button type="button" class="btn btn-outline-light btn-sm" id="importFileBtn">
                                 <i class="fas fa-upload me-1"></i><span class="d-none d-sm-inline">Import </span>File
                             </button>
@@ -617,11 +617,14 @@ volumes:
 };
 
 // Template modal functionality
-document.getElementById('loadTemplateBtn').addEventListener('click', function() {
-    const modal = new bootstrap.Modal(document.getElementById('templateModal'));
-    loadTemplateCategory('web');
-    modal.show();
-});
+const loadTemplateBtn = document.getElementById('loadTemplateBtn');
+if (loadTemplateBtn) {
+    loadTemplateBtn.addEventListener('click', function() {
+        const modal = new bootstrap.Modal(document.getElementById('templateModal'));
+        loadTemplateCategory('web');
+        modal.show();
+    });
+}
 
 document.getElementById('templateCategories').addEventListener('click', function(e) {
     if (e.target.classList.contains('list-group-item')) {


### PR DESCRIPTION
## Summary
- comment out the Load Templates button in `create.php`
- guard template loader script against missing button

## Testing
- `php -l pages/create.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9b2d8108321b3bb2bbb405c9fed