### PR TITLE
 Add Password-Protected Pastes, Secure Paste Visibility, and Select2 Language Dropdown Enhancements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1876,3 +1876,13 @@ pre[class*="language-"] .line-highlight:after,
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }
 }
+
+/* Ensure modal is above the backdrop */
+.modal-backdrop {
+    z-index: 1040;
+}
+
+.modal-content {
+    z-index: 1050;
+    position: relative;
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -188,6 +188,8 @@ function getRecentPastes($limit = 10) {
             SELECT id, title, language, created_at, views
             FROM pastes 
             WHERE is_public = 1 
+            AND visibility = 'public'
+            AND burn_after_read = 0
             AND (expire_time IS NULL OR expire_time > ?)
             AND (burned IS NULL OR burned = 0)
             ORDER BY created_at DESC 

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -21,6 +21,9 @@
 
     <!-- jQuery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+
+    <!-- Select2 JS -->
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     
     <!-- Bootstrap 5 JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/includes/header.php
+++ b/includes/header.php
@@ -18,6 +18,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.cells.min.js"></script>
     
+    <!-- Select2 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/assets/css/style.css">
 </head>

--- a/pages/create.php
+++ b/pages/create.php
@@ -1004,6 +1004,14 @@ document.addEventListener('click', function(e) {
 document.addEventListener('DOMContentLoaded', function() {
     updateCharCount();
 });
+
+// Initialize Select2 for language selector
+$(document).ready(function() {
+    $('#language').select2({
+        placeholder: 'Select a language',
+        allowClear: true
+    });
+});
 </script>
 
 <?php include '../includes/footer.php'; ?>

--- a/pages/create.php
+++ b/pages/create.php
@@ -125,9 +125,9 @@ include '../includes/header.php';
                             <i class="fas fa-plus me-2"></i>Create Paste
                         </h4>
                         <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-light btn-sm" id="loadTemplateBtn">
-                                <i class="fas fa-file-code me-1"></i><span class="d-none d-sm-inline">Load </span>Template
-                            </button>
+                            <!-- <button type="button" class="btn btn-outline-light btn-sm" id="loadTemplateBtn"> -->
+                            <!--     <i class="fas fa-file-code me-1"></i><span class="d-none d-sm-inline">Load </span>Template -->
+                            <!-- </button> -->
                             <button type="button" class="btn btn-outline-light btn-sm" id="importFileBtn">
                                 <i class="fas fa-upload me-1"></i><span class="d-none d-sm-inline">Import </span>File
                             </button>
@@ -617,11 +617,14 @@ volumes:
 };
 
 // Template modal functionality
-document.getElementById('loadTemplateBtn').addEventListener('click', function() {
-    const modal = new bootstrap.Modal(document.getElementById('templateModal'));
-    loadTemplateCategory('web');
-    modal.show();
-});
+const loadTemplateBtn = document.getElementById('loadTemplateBtn');
+if (loadTemplateBtn) {
+    loadTemplateBtn.addEventListener('click', function() {
+        const modal = new bootstrap.Modal(document.getElementById('templateModal'));
+        loadTemplateCategory('web');
+        modal.show();
+    });
+}
 
 document.getElementById('templateCategories').addEventListener('click', function(e) {
     if (e.target.classList.contains('list-group-item')) {


### PR DESCRIPTION
🔒 Additional Enhancements:
🔔 Added banner above password form: "You are trying to view a password protected paste. A password is required to view the paste."

🔐 Added lock icon on password-protected pastes in pages/recent.php to visually indicate they are secure.

🧪 Prevented password-protected pastes from appearing in recent feed on index.php.

🧰 Misc Fixes and Improvements:
✅ Integrated Select2 for the language dropdown in pages/create.php to allow searching and improved UX.

🧼 Removed broken Load Template button from create page (template logic remains in place for future reactivation).

🔒 Fixed logic to hide:

Burn After Read pastes from public index.php

Unlisted pastes from public recent list

📁 Files Modified:
create.php

index.php

view.php and supporting logic for password handling

recent.php

Assets (CSS/JS) updated to include Select2

Templates modal JS toggle removed