### PR TITLE
Fix paste creation function load

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/db.php';
+?>

--- a/pages/create.php
+++ b/pages/create.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once '../includes/db.php';
+require_once '../includes/functions.php';
 require_once '../database/init.php';
 $success = false;
 $error = '';


### PR DESCRIPTION
## Summary
- add a functions.php include to load helper functions
- ensure create.php loads the helper file

## Testing
- `composer install` *(fails: command not found)*
- `php -l pages/create.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864abc632a48321bd34fc365109b9c1