### PR TITLE
Fix flag report path

### DIFF
--- a/includes/audit_logger.php
+++ b/includes/audit_logger.php
@@ -1,0 +1,8 @@
+<?php
+function log_audit($message) {
+    // Basic audit logging implementation
+    $logFile = __DIR__ . '/../database/audit.log';
+    $entry = date('c') . " | " . $message . PHP_EOL;
+    file_put_contents($logFile, $entry, FILE_APPEND);
+}
+?>

--- a/includes/settings_helper.php
+++ b/includes/settings_helper.php
@@ -1,0 +1,6 @@
+<?php
+function get_setting($key, $default = null) {
+    // Simple placeholder for retrieving application settings
+    return $default;
+}
+?>

--- a/pages/flag_paste.php
+++ b/pages/flag_paste.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
-require_once __DIR__ . '/includes/db.php';
-require_once __DIR__ . '/database/init.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../database/init.php';
 
 $pdo = getDatabase();
 


### PR DESCRIPTION
## Summary
- move `flag_paste.php` into `pages/`
- fix include paths in the moved file
- add placeholder `audit_logger.php` and `settings_helper.php` to `includes`

## Testing
- `php -l pages/flag_paste.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866faf9b9a48321a060b3ae422ec891