### PR TITLE
Disable duplicate paste reports

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1883,3 +1883,9 @@ pre[class*="language-"] .line-highlight:after,
 .badge.severity-2 { background-color: var(--warning-color); color: #000; }
 .badge.severity-3 { background-color: var(--danger-color); }
 .badge.severity-4 { background-color: #6f42c1; }
+
+/* Disabled buttons */
+button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- track whether an IP address has already flagged a paste
- disable the *Report* button in `view.php` when it has been flagged
- style disabled buttons

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686700adcfa4832183efc9da77e2669d