### PR TITLE
Fix report only once

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1883,3 +1883,9 @@ pre[class*="language-"] .line-highlight:after,
 .badge.severity-2 { background-color: var(--warning-color); color: #000; }
 .badge.severity-3 { background-color: var(--danger-color); }
 .badge.severity-4 { background-color: #6f42c1; }
+
+/* Disabled buttons */
+button[disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
+}


### PR DESCRIPTION
Introduced a check in the view page that looks for existing flags by IP, setting a boolean to disable duplicate reports

Disabled the desktop “Report” button when a user from the same IP already flagged the paste, informing them it’s already reported

Disabled the mobile dropdown “Report Paste” option in the same scenario, displaying a muted message instead of an actionable link

Added styling for disabled buttons so they appear grayed out and have a “not-allowed” cursor