### PR TITLE
Fix chain tab for parent paste

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -503,6 +503,13 @@ function addDiscussionPost($threadId, $content, $username = 'Anonymous') {
     return $db->lastInsertId();
 }
 
+function getChainCount($pasteId) {
+    $db = getDatabase();
+    $stmt = $db->prepare("SELECT COUNT(*) FROM pastes WHERE parent_paste_id = ?");
+    $stmt->execute([$pasteId]);
+    return (int) $stmt->fetchColumn();
+}
+
 function getDiscussionThread($threadId) {
     $db = getDatabase();
     $stmt = $db->prepare("

--- a/pages/view.php
+++ b/pages/view.php
@@ -201,11 +201,8 @@ if (empty($pasteId)) {
                 $origin = $origin_q->fetch(PDO::FETCH_ASSOC);
 
                 // Get chain continuations count
-                $chainStmt = $db->prepare("SELECT COUNT(*) as chain_count FROM pastes WHERE parent_paste_id = ?");
-                $chainStmt->execute([$pasteId]);
-                $chainData = $chainStmt->fetch();
-                $paste['chain_count'] = $chainData['chain_count'] ?? 0;
-                $chainCount = $paste['chain_count'];
+                $chainCount = getChainCount($pasteId);
+                $paste['chain_count'] = $chainCount;
                 
                 // Get comments count
                 $stmt = $db->prepare("SELECT COUNT(*) as comment_count FROM comments WHERE paste_id = ? AND is_deleted = 0");


### PR DESCRIPTION
## Summary
- add helper `getChainCount` for counting child pastes
- use the helper in `view.php` when loading a paste

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867493a34948321bfed8daa1fa922f9