### PR TITLE
Fix chain/fork tab visibility

### DIFF
--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -20,10 +20,14 @@
                             </button>
                         </li>
                         <?php if ($paste['fork_count'] > 0): ?>
-                        <li class="nav-item" role="presentation">
-                            <button class="nav-link border-0 fw-semibold" id="forks-tab" data-bs-toggle="tab" data-bs-target="#forks" type="button" role="tab">
-                                <i class="fas fa-code-branch me-2"></i>Forks <span class="badge bg-secondary ms-1"><?php echo $paste['fork_count']; ?></span>
-                            </button>
+                        <li class="nav-item">
+                            <a class="nav-link" id="forks-tab" data-bs-toggle="tab" href="#forks" role="tab" aria-controls="forks" aria-selected="false">Forks</a>
+                        </li>
+                        <?php endif; ?>
+
+                        <?php if ($paste['version_count'] > 1): ?>
+                        <li class="nav-item">
+                            <a class="nav-link" id="chain-tab" data-bs-toggle="tab" href="#chain" role="tab" aria-controls="chain" aria-selected="false">Chain</a>
                         </li>
                         <?php endif; ?>
                         <!-- Comments and Discussions tabs - hidden for ZKE pastes without decryption key -->
@@ -84,12 +88,43 @@
                         <div class="tab-pane fade" id="related" role="tabpanel">
                             <div class="p-4">
                                 <h6 class="fw-semibold mb-3">Related Pastes</h6>
-                                <div class="alert alert-info">
-                                    <i class="fas fa-search me-2"></i>
-                                    Smart content discovery based on language, tags, and similarity analysis coming soon!
-                                </div>
+                        <div class="alert alert-info">
+                            <i class="fas fa-search me-2"></i>
+                            Smart content discovery based on language, tags, and similarity analysis coming soon!
+                        </div>
+                        </div>
+                        </div>
+
+                        <!-- Chain Tab -->
+                        <?php if ($paste['version_count'] > 1): ?>
+                        <div class="tab-pane fade" id="chain" role="tabpanel">
+                            <div class="p-4">
+                                <h6 class="fw-semibold mb-3">Chain Continuations</h6>
+                                <?php
+                                    $chainList = $db->prepare(
+                                        "SELECT p.*, u.username, u.profile_image FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.parent_paste_id = ? ORDER BY p.created_at ASC LIMIT 10"
+                                    );
+                                    $chainList->execute([$pasteId]);
+                                    foreach ($chainList as $chain) {
+                                ?>
+                                    <div class="chain-item mb-3">
+                                        <img src="<?= $chain['profile_image'] ?? '/img/default-avatar.png' ?>" width="30" class="me-2 rounded-circle">
+                                        <strong><?= htmlspecialchars($chain['title']) ?></strong> by <?= htmlspecialchars($chain['username'] ?? 'Anonymous') ?>
+                                        <div class="small text-muted">
+                                            <?= date('M j, Y H:i', $chain['created_at']) ?> — <?= $chain['views'] ?> views
+                                        </div>
+                                        <div>
+                                            <a href="/pages/view.php?id=<?= $chain['id'] ?>" class="me-2">View</a>
+                                            <a href="/pages/create.php?parent=<?= $pasteId ?>">Continue Chain</a>
+                                        </div>
+                                    </div>
+                                <?php } ?>
+                                <?php if ($paste['version_count'] > 10): ?>
+                                    <div class="text-muted">+<?= $paste['version_count'] - 10 ?> more in chain...</div>
+                                <?php endif; ?>
                             </div>
                         </div>
+                        <?php endif; ?>
 
                         <!-- Forks Tab -->
                         <?php if ($paste['fork_count'] > 0): ?>

--- a/pages/view.php
+++ b/pages/view.php
@@ -23,6 +23,23 @@ if (!empty($pasteId)) {
             exit;
         }
     }
+
+    if ($paste) {
+        $db = getDatabase();
+
+        // Get the number of forks
+        $stmtForkCount = $db->prepare("SELECT COUNT(*) FROM paste_forks WHERE original_paste_id = ?");
+        $stmtForkCount->execute([$paste['id']]);
+        $paste['fork_count'] = (int) $stmtForkCount->fetchColumn();
+
+        // Get the number of versions/chain continuations
+        $stmtChainCount = $db->prepare("SELECT COUNT(*) FROM pastes WHERE chain_parent_id = ?");
+        $stmtChainCount->execute([$paste['id']]);
+        $paste['version_count'] = (int) $stmtChainCount->fetchColumn();
+
+        $forkCount = $paste['fork_count'];
+        $chainCount = $paste['version_count'];
+    }
 }
 
 $parent = null;
@@ -175,23 +192,10 @@ if (empty($pasteId)) {
                 $flagCheck->execute([$pasteId, $ip]);
                 $hasFlagged = $flagCheck->fetchColumn() !== false;
                 
-                // Get versions count
-                $stmt = $db->prepare("SELECT COUNT(*) as version_count FROM paste_versions WHERE paste_id = ?");
-                $stmt->execute([$pasteId]);
-                $versionData = $stmt->fetch();
-                $paste['version_count'] = $versionData['version_count'] ?? 0;
-
                 // Fetch all versions if more than one exists
                 $versionStmt = $db->prepare("SELECT * FROM paste_versions WHERE paste_id = ? ORDER BY version_number DESC");
                 $versionStmt->execute([$pasteId]);
                 $versions = $versionStmt->fetchAll(PDO::FETCH_ASSOC);
-                
-                // Get forks count
-                $forks_q = $db->prepare("SELECT COUNT(*) FROM paste_forks WHERE original_paste_id = ?");
-                $forks_q->execute([$pasteId]);
-                $fork_count = $forks_q->fetchColumn();
-                $paste['fork_count'] = $fork_count ?: 0;
-                $forkCount = $paste['fork_count'];
 
                 // Determine if this paste is a fork of another
                 $origin_q = $db->prepare(
@@ -200,12 +204,6 @@ if (empty($pasteId)) {
                 $origin_q->execute([$pasteId]);
                 $origin = $origin_q->fetch(PDO::FETCH_ASSOC);
 
-                // Get chain continuations count
-                $chainStmt = $db->prepare("SELECT COUNT(*) as chain_count FROM pastes WHERE parent_paste_id = ?");
-                $chainStmt->execute([$pasteId]);
-                $chainData = $chainStmt->fetch();
-                $paste['chain_count'] = $chainData['chain_count'] ?? 0;
-                $chainCount = $paste['chain_count'];
                 
                 // Get comments count
                 $stmt = $db->prepare("SELECT COUNT(*) as comment_count FROM comments WHERE paste_id = ? AND is_deleted = 0");
@@ -227,7 +225,6 @@ if (empty($pasteId)) {
                 $paste['version_count'] = 1;
                 $paste['fork_count'] = 0;
                 $forkCount = 0;
-                $paste['chain_count'] = 0;
                 $chainCount = 0;
                 $paste['comment_count'] = 0;
                 $comments = [];


### PR DESCRIPTION
## Summary
- fetch fork and chain counts when loading a paste
- display Forks and Chain tabs when counts warrant
- render chain tab content in view tabs

## Testing
- `php -l pages/view.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868211e07dc8321ac31ec9531fae069