### PR TITLE
Fix chain links by adding missing column

### DIFF
--- a/database/init.php
+++ b/database/init.php
@@ -38,6 +38,16 @@ function initializeDatabase($pdo = null) {
     }
 }
 
+function ensureChainParentColumn(PDO $pdo) {
+    $columns = $pdo->query("PRAGMA table_info(pastes)")->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($columns as $column) {
+        if ($column['name'] === 'chain_parent_id') {
+            return; // Column already exists
+        }
+    }
+    $pdo->exec("ALTER TABLE pastes ADD COLUMN chain_parent_id TEXT");
+}
+
 // Run initialization if called directly
 if (basename(__FILE__) == basename($_SERVER['PHP_SELF'])) {
     if (initializeDatabase()) {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS "pastes" (
         "source_url"    TEXT DEFAULT NULL,
         "imported_from" TEXT DEFAULT NULL,
         "parent_paste_id"       INTEGER DEFAULT NULL,
+        "chain_parent_id" TEXT,
         "ai_summary_id" INTEGER DEFAULT NULL,
         PRIMARY KEY("id")
 );

--- a/includes/db.php
+++ b/includes/db.php
@@ -23,11 +23,15 @@ function getDatabase() {
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         
+        require_once __DIR__ . '/../database/init.php';
+
         // Initialize database if needed
         if (!file_exists($dbPath) || filesize($dbPath) == 0) {
-            require_once __DIR__ . '/../database/init.php';
             initializeDatabase($pdo);
         }
+
+        // Ensure migrations are applied
+        ensureChainParentColumn($pdo);
         
         return $pdo;
     } catch (PDOException $e) {
@@ -147,8 +151,8 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             INSERT INTO pastes (
                 id, title, content, language, expire_time, created_at,
                 is_public, password, burn_after_read, zero_knowledge, creator_token, visibility,
-                parent_paste_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                parent_paste_id, chain_parent_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ");
         
         $stmt->execute([
@@ -164,6 +168,7 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             $zeroKnowledge ? 1 : 0,
             $creatorToken,
             $visibility,
+            $parentPasteId,
             $parentPasteId
         ]);
         

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -19,8 +19,8 @@ function createPasteAdvanced($db, $title, $content, $language, $userId = null, $
     $slug = bin2hex(random_bytes(8));
     $createdAt = date('Y-m-d H:i:s');
 
-    $stmt = $db->prepare("INSERT INTO pastes (paste_id, title, content, language, user_id, parent_paste_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)");
-    $stmt->execute([$slug, $title, $content, $language, $userId, $parentPasteId, $createdAt]);
+    $stmt = $db->prepare("INSERT INTO pastes (paste_id, title, content, language, user_id, parent_paste_id, chain_parent_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+    $stmt->execute([$slug, $title, $content, $language, $userId, $parentPasteId, $parentPasteId, $createdAt]);
 
     $pasteId = $slug;
 

--- a/pages/view.php
+++ b/pages/view.php
@@ -734,6 +734,7 @@ include '../includes/header.php';
             </div>
 
             <!-- Tab Navigation -->
+<?php if ($chainCount > 0 || $forkCount > 0): ?>
             <div class="card border-0 shadow-sm">
                 <div class="card-header bg-transparent border-0 p-0">
                     <ul class="nav nav-tabs border-0" id="pasteViewTabs" role="tablist">
@@ -937,7 +938,7 @@ include '../includes/header.php';
                                 <h6 class="fw-semibold mb-3">Chain Continuations</h6>
                                 <?php
                                     $chainList = $db->prepare(
-                                        "SELECT p.*, u.username, u.profile_image FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.parent_paste_id = ? ORDER BY p.created_at ASC LIMIT 10"
+                                        "SELECT p.*, u.username, u.profile_image FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.chain_parent_id = ? ORDER BY p.created_at DESC LIMIT 10"
                                     );
                                     $chainList->execute([$pasteId]);
                                     foreach ($chainList as $chain) {
@@ -2055,6 +2056,7 @@ include '../includes/header.php';
 
         </div>
     </div>
+<?php endif; ?>
     <?php endif; ?>
 </main>
 


### PR DESCRIPTION
## Summary
- add runtime migration to ensure `chain_parent_id` exists
- use new column when inserting and retrieving chain data
- display chain and fork tabs only when counts are non-zero
- revert change to bundled SQLite database

## Testing
- `sqlite3 database/pastebin.db "ALTER TABLE pastes ADD COLUMN chain_parent_id TEXT;"`
- `sqlite3 database/pastebin.db "PRAGMA table_info(pastes);" | grep chain_parent_id`
- `sqlite3 database/pastebin.db "SELECT COUNT(*) FROM pastes WHERE chain_parent_id IS NOT NULL;"`


------
https://chatgpt.com/codex/tasks/task_e_686827fd53408321994b555cd14549fd