### PR TITLE
Sort forks tab by newest first

### DIFF
--- a/pages/view.php
+++ b/pages/view.php
@@ -971,7 +971,7 @@ include '../includes/header.php';
                                 <h6 class="fw-semibold mb-3">Forks</h6>
                                 <?php
                                     $forkList = $db->prepare(
-                                        "SELECT p.*, u.username, u.profile_image FROM paste_forks f JOIN pastes p ON f.forked_paste_id = p.id LEFT JOIN users u ON f.forked_by_user_id = u.id WHERE f.original_paste_id = ? ORDER BY f.created_at DESC LIMIT 10"
+                                        "SELECT p.*, u.username, u.profile_image FROM paste_forks f JOIN pastes p ON f.forked_paste_id = p.id LEFT JOIN users u ON f.forked_by_user_id = u.id WHERE f.original_paste_id = ? ORDER BY p.created_at DESC LIMIT 10"
                                     );
                                     $forkList->execute([$pasteId]);
                                     foreach ($forkList as $fork) {


### PR DESCRIPTION
## Summary
- sort fork listings in view.php so new forks appear first

## Testing
- `php -l pages/view.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686841a470e083219a855ddc4122d966