### PR TITLE
Add login/signup to navbar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -392,6 +392,10 @@ input.burn-link-input:focus,
     padding: 0.5rem 1rem !important;
 }
 
+.navbar .nav-link {
+    margin-left: 10px;
+}
+
 .navbar-nav .nav-link:hover {
     background-color: rgba(59, 130, 246, 0.1);
     color: var(--primary-color) !important;

--- a/includes/header.php
+++ b/includes/header.php
@@ -55,13 +55,13 @@
                             <i class="fas fa-clock me-1"></i>Recent Pastes
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">
+                    <li class="nav-item d-lg-none">
+                        <a class="nav-link" href="/login.php">
                             <i class="fas fa-sign-in-alt me-1"></i>Login
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">
+                    <li class="nav-item d-lg-none">
+                        <a class="nav-link" href="/register.php">
                             <i class="fas fa-user-plus me-1"></i>Sign Up
                         </a>
                     </li>
@@ -72,6 +72,10 @@
                     <button class="btn btn-outline-light btn-sm me-2" id="themeToggle" type="button">
                         <i class="fas fa-moon" id="themeIcon"></i>
                     </button>
+                </div>
+                <div class="d-none d-lg-flex align-items-center ms-auto">
+                    <a href="/login.php" class="nav-link"><i class="fas fa-sign-in-alt"></i> Login</a>
+                    <a href="/register.php" class="nav-link"><i class="fas fa-user-plus"></i> Sign Up</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show Login and Sign Up links in the navbar
- hide them in desktop nav list but show in dropdown
- add desktop links next to theme toggle
- style navbar links for consistent spacing

## Testing
- `composer validate --no-check-all --no-check-lock` *(fails: composer missing)*

------
https://chatgpt.com/codex/tasks/task_e_68686fd6e7048321a59ec3f64ea3616a