### PR TITLE
Add login page and dynamic navbar

### DIFF
--- a/img/default-avatar.svg
+++ b/img/default-avatar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="#ccc">
+  <circle cx="32" cy="24" r="16" fill="#bbb"/>
+  <path d="M16 52c0-8.8 7.2-16 16-16s16 7.2 16 16" fill="#bbb"/>
+</svg>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,3 +1,20 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($pdo)) {
+    require_once __DIR__ . '/db.php';
+}
+$userData = null;
+if (isset($_SESSION['user_id'])) {
+    $stmt = $pdo->prepare("SELECT username, profile_image FROM users WHERE id = ?");
+    $stmt->execute([$_SESSION['user_id']]);
+    $userData = $stmt->fetch();
+    if ($userData) {
+        $userData['avatar'] = $userData['profile_image'] ?: '/img/default-avatar.svg';
+    }
+}
+?>
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="light">
 <head>
@@ -55,6 +72,17 @@
                             <i class="fas fa-clock me-1"></i>Recent Pastes
                         </a>
                     </li>
+<?php if ($userData): ?>
+                    <li class="nav-item d-lg-none dropdown">
+                        <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="mobileUserDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <img src="<?php echo htmlspecialchars($userData['avatar']); ?>" width="24" height="24" class="rounded-circle me-2">
+                            <?php echo htmlspecialchars($userData['username']); ?>
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="mobileUserDropdown">
+                            <li><span class="dropdown-item">Coming Soon</span></li>
+                        </ul>
+                    </li>
+<?php else: ?>
                     <li class="nav-item d-lg-none">
                         <a class="nav-link" href="/login.php">
                             <i class="fas fa-sign-in-alt me-1"></i>Login
@@ -65,6 +93,7 @@
                             <i class="fas fa-user-plus me-1"></i>Sign Up
                         </a>
                     </li>
+<?php endif; ?>
                 </ul>
 
                 <!-- Dark Mode Toggle and Auth Buttons -->
@@ -73,8 +102,20 @@
                         <i class="fas fa-moon" id="themeIcon"></i>
                     </button>
                     <div class="d-none d-lg-flex align-items-center">
+<?php if ($userData): ?>
+                        <div class="dropdown">
+                            <a href="#" class="nav-link dropdown-toggle d-flex align-items-center" id="userDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                                <img src="<?php echo htmlspecialchars($userData['avatar']); ?>" width="30" height="30" class="rounded-circle me-2">
+                                <span><?php echo htmlspecialchars($userData['username']); ?></span>
+                            </a>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                                <li><span class="dropdown-item">Coming Soon</span></li>
+                            </ul>
+                        </div>
+<?php else: ?>
                         <a href="/login.php" class="nav-link me-2"><i class="fas fa-sign-in-alt"></i> Login</a>
                         <a href="/register.php" class="nav-link"><i class="fas fa-user-plus"></i> Sign Up</a>
+<?php endif; ?>
                     </div>
                 </div>
             </div>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,60 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+require_once 'includes/db.php';
+require_once 'database/init.php';
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+
+    if ($username === '' || $password === '') {
+        $error = 'Username and password are required.';
+    } else {
+        $stmt = $pdo->prepare("SELECT id, username, password FROM users WHERE username = ?");
+        $stmt->execute([$username]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['password'])) {
+            $_SESSION['user_id'] = $user['id'];
+            header('Location: index.php');
+            exit();
+        } else {
+            $error = 'Incorrect username or password, please try again.';
+        }
+    }
+}
+
+$pageTitle = 'Login';
+include 'includes/header.php';
+?>
+<main class="container-fluid px-4 py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6 col-lg-5">
+            <div class="card border-0 shadow-lg">
+                <div class="card-header border-0 bg-primary text-white py-3">
+                    <h4 class="mb-0"><i class="fas fa-sign-in-alt me-2"></i>Login</h4>
+                </div>
+                <div class="card-body p-4">
+                    <?php if ($error): ?>
+                        <div class="alert alert-warning"><?php echo htmlspecialchars($error); ?></div>
+                    <?php endif; ?>
+                    <form method="POST" action="login.php" class="needs-validation" novalidate>
+                        <div class="mb-3 form-group">
+                            <label for="username" class="form-label">Username *</label>
+                            <input type="text" class="form-control" name="username" id="username" required>
+                        </div>
+                        <div class="mb-3 form-group">
+                            <label for="password" class="form-label">Password *</label>
+                            <input type="password" class="form-control" name="password" id="password" required>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Login</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add new login form with username and password validation
- include simple default avatar asset
- update header to start sessions and show logged in user information

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687f427b408321bfc2130af8406cb5