### PR TITLE
Enable guest mode pasting for logged-in users

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -69,9 +69,14 @@ function generatePasteId($length = 8) {
  */
 function getPasteById($id) {
     global $pdo;
-    
+
     try {
-        $stmt = $pdo->prepare("SELECT * FROM pastes WHERE id = ?");
+        $stmt = $pdo->prepare(
+            "SELECT p.*, u.username, u.profile_image
+             FROM pastes p
+             LEFT JOIN users u ON p.user_id = u.id
+             WHERE p.id = ?"
+        );
         $stmt->execute([$id]);
         return $stmt->fetch();
     } catch (PDOException $e) {
@@ -108,7 +113,7 @@ function createPaste($title, $content, $language, $expiration = null) {
 /**
  * Create a new paste with advanced features
  */
-function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null) {
+function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null, $userId = null) {
     global $pdo;
     
     $id = generatePasteId();
@@ -147,8 +152,8 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             INSERT INTO pastes (
                 id, title, content, language, expire_time, created_at,
                 is_public, password, burn_after_read, zero_knowledge, creator_token, visibility,
-                parent_paste_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                parent_paste_id, user_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ");
         
         $stmt->execute([
@@ -164,7 +169,8 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             $zeroKnowledge ? 1 : 0,
             $creatorToken,
             $visibility,
-            $parentPasteId
+            $parentPasteId,
+            $userId
         ]);
         
         // Return appropriate format based on burn after read

--- a/pages/create.php
+++ b/pages/create.php
@@ -29,6 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = trim($_POST['password'] ?? '');
     $burnAfterRead = isset($_POST['burn_after_read']);
     $zeroKnowledge = isset($_POST['zero_knowledge']);
+    $pasteAsGuest = isset($_POST['paste_as_guest']);
     $parentPasteId = $_POST['parent_paste_id'] ?? null;
     
     if (empty($content)) {
@@ -66,8 +67,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         
         // Hash password if provided
         $hashedPassword = $password ? password_hash($password, PASSWORD_DEFAULT) : null;
-        
-        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId);
+
+        $userId = null;
+        if (isset($_SESSION['user_id']) && !$pasteAsGuest) {
+            $userId = $_SESSION['user_id'];
+        }
+
+        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId, $userId);
         
         if ($result) {
             // Handle different return formats for compatibility
@@ -337,6 +343,13 @@ include '../includes/header.php';
                                         <label class="form-check-label" for="burnAfterRead">
                                             <i class="fas fa-fire me-1 text-danger"></i>Burn After Read
                                             <small class="d-block text-muted">Delete after first view</small>
+                                        </label>
+                                    </div>
+                                    <div class="form-check mt-2">
+                                        <input class="form-check-input" type="checkbox" id="pasteAsGuest" name="paste_as_guest">
+                                        <label class="form-check-label" for="pasteAsGuest">
+                                            <i class="fas fa-user-secret me-1"></i>Paste as a guest
+                                            <small class="d-block text-muted">Post anonymously even while logged in.</small>
                                         </label>
                                     </div>
                                 </div>

--- a/pages/view.php
+++ b/pages/view.php
@@ -691,7 +691,11 @@ include '../includes/header.php';
                     </div>
                     
                     <!-- Metadata Row -->
-                    <div class="d-flex flex-wrap gap-3 text-muted small">
+                    <div class="d-flex flex-wrap gap-3 text-muted small align-items-center">
+                        <span class="d-flex align-items-center">
+                            <img src="<?php echo htmlspecialchars($paste['profile_image'] ?: '/img/default-avatar.svg'); ?>" alt="Avatar" class="rounded-circle me-1" width="24" height="24">
+                            <?php echo htmlspecialchars($paste['username'] ?? 'Anonymous'); ?>
+                        </span>
                         <span class="badge bg-primary-subtle text-primary px-3 py-2">
                             <i class="fas fa-code me-1"></i>
                             <?php echo htmlspecialchars($paste['language']); ?>
@@ -946,7 +950,7 @@ include '../includes/header.php';
                                     foreach ($chainList as $chain) {
                                 ?>
                                     <div class="chain-item mb-3">
-                                        <img src="<?= $chain['profile_image'] ?? '/img/default-avatar.png' ?>" width="30" class="me-2 rounded-circle">
+                                        <img src="<?= $chain['profile_image'] ?? '/img/default-avatar.svg' ?>" width="30" class="me-2 rounded-circle">
                                         <strong><?= htmlspecialchars($chain['title']) ?></strong> by <?= htmlspecialchars($chain['username'] ?? 'Anonymous') ?>
                                         <div class="small text-muted">
                                             <?= date('M j, Y H:i', $chain['created_at']) ?> — <?= $chain['views'] ?> views
@@ -977,7 +981,7 @@ include '../includes/header.php';
                                     foreach ($forkList as $fork) {
                                 ?>
                                     <div class="fork-item mb-3">
-                                        <img src="<?= $fork['profile_image'] ?? '/img/default-avatar.png' ?>" width="30" class="me-2 rounded-circle">
+                                        <img src="<?= $fork['profile_image'] ?? '/img/default-avatar.svg' ?>" width="30" class="me-2 rounded-circle">
                                         <strong><?= htmlspecialchars($fork['title']) ?></strong> by <?= htmlspecialchars($fork['username'] ?? 'Anonymous') ?>
                                         <div class="small text-muted">
                                             <?= date('M j, Y H:i', $fork['created_at']) ?> — <?= $fork['views'] ?> views


### PR DESCRIPTION
## Summary
- allow optional guest mode when creating a paste
- store user id with paste creation and show author avatar
- fetch username & avatar when retrieving pastes
- display author info in paste view
- remove PNG avatar and use existing SVG icon

## Testing
- `php -l includes/db.php` *(fails: command not found)*
- `php -l includes/header.php` *(fails: command not found)*
- `php -l pages/create.php` *(fails: command not found)*
- `php -l pages/view.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698b8c72448321b97e7b7e3f07b099