### PR TITLE
UI/paste options update

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -69,9 +69,14 @@ function generatePasteId($length = 8) {
  */
 function getPasteById($id) {
     global $pdo;
-    
+
     try {
-        $stmt = $pdo->prepare("SELECT * FROM pastes WHERE id = ?");
+        $stmt = $pdo->prepare(
+            "SELECT p.*, u.username, u.profile_image
+             FROM pastes p
+             LEFT JOIN users u ON p.user_id = u.id
+             WHERE p.id = ?"
+        );
         $stmt->execute([$id]);
         return $stmt->fetch();
     } catch (PDOException $e) {
@@ -108,7 +113,7 @@ function createPaste($title, $content, $language, $expiration = null) {
 /**
  * Create a new paste with advanced features
  */
-function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null) {
+function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null, $userId = null) {
     global $pdo;
     
     $id = generatePasteId();
@@ -147,8 +152,8 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             INSERT INTO pastes (
                 id, title, content, language, expire_time, created_at,
                 is_public, password, burn_after_read, zero_knowledge, creator_token, visibility,
-                parent_paste_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                parent_paste_id, user_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ");
         
         $stmt->execute([
@@ -164,7 +169,8 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             $zeroKnowledge ? 1 : 0,
             $creatorToken,
             $visibility,
-            $parentPasteId
+            $parentPasteId,
+            $userId
         ]);
         
         // Return appropriate format based on burn after read

--- a/pages/create.php
+++ b/pages/create.php
@@ -29,6 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = trim($_POST['password'] ?? '');
     $burnAfterRead = isset($_POST['burn_after_read']);
     $zeroKnowledge = isset($_POST['zero_knowledge']);
+    $pasteAsGuest = isset($_POST['paste_as_guest']);
     $parentPasteId = $_POST['parent_paste_id'] ?? null;
     
     if (empty($content)) {
@@ -66,8 +67,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         
         // Hash password if provided
         $hashedPassword = $password ? password_hash($password, PASSWORD_DEFAULT) : null;
-        
-        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId);
+
+        $userId = null;
+        if (isset($_SESSION['user_id']) && !$pasteAsGuest) {
+            $userId = $_SESSION['user_id'];
+        }
+
+        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId, $userId);
         
         if ($result) {
             // Handle different return formats for compatibility
@@ -337,6 +343,13 @@ include '../includes/header.php';
                                         <label class="form-check-label" for="burnAfterRead">
                                             <i class="fas fa-fire me-1 text-danger"></i>Burn After Read
                                             <small class="d-block text-muted">Delete after first view</small>
+                                        </label>
+                                    </div>
+                                    <div class="form-check mt-2">
+                                        <input class="form-check-input" type="checkbox" id="pasteAsGuest" name="paste_as_guest">
+                                        <label class="form-check-label" for="pasteAsGuest">
+                                            <i class="fas fa-user-secret me-1"></i>Paste as a guest
+                                            <small class="d-block text-muted">Post anonymously even while logged in.</small>
                                         </label>
                                     </div>
                                 </div>

--- a/pages/view.php
+++ b/pages/view.php
@@ -691,7 +691,11 @@ include '../includes/header.php';
                     </div>
                     
                     <!-- Metadata Row -->
-                    <div class="d-flex flex-wrap gap-3 text-muted small">
+                    <div class="d-flex flex-wrap gap-3 text-muted small align-items-center">
+                        <span class="d-flex align-items-center">
+                            <img src="<?php echo htmlspecialchars($paste['profile_image'] ?: '/img/default-avatar.svg'); ?>" alt="Avatar" class="rounded-circle me-1" width="24" height="24">
+                            <?php echo htmlspecialchars($paste['username'] ?? 'Anonymous'); ?>
+                        </span>
                         <span class="badge bg-primary-subtle text-primary px-3 py-2">
                             <i class="fas fa-code me-1"></i>
                             <?php echo htmlspecialchars($paste['language']); ?>
@@ -946,7 +950,7 @@ include '../includes/header.php';
                                     foreach ($chainList as $chain) {
                                 ?>
                                     <div class="chain-item mb-3">
-                                        <img src="<?= $chain['profile_image'] ?? '/img/default-avatar.png' ?>" width="30" class="me-2 rounded-circle">
+                                        <img src="<?= $chain['profile_image'] ?? '/img/default-avatar.svg' ?>" width="30" class="me-2 rounded-circle">
                                         <strong><?= htmlspecialchars($chain['title']) ?></strong> by <?= htmlspecialchars($chain['username'] ?? 'Anonymous') ?>
                                         <div class="small text-muted">
                                             <?= date('M j, Y H:i', $chain['created_at']) ?> — <?= $chain['views'] ?> views
@@ -977,7 +981,7 @@ include '../includes/header.php';
                                     foreach ($forkList as $fork) {
                                 ?>
                                     <div class="fork-item mb-3">
-                                        <img src="<?= $fork['profile_image'] ?? '/img/default-avatar.png' ?>" width="30" class="me-2 rounded-circle">
+                                        <img src="<?= $fork['profile_image'] ?? '/img/default-avatar.svg' ?>" width="30" class="me-2 rounded-circle">
                                         <strong><?= htmlspecialchars($fork['title']) ?></strong> by <?= htmlspecialchars($fork['username'] ?? 'Anonymous') ?>
                                         <div class="small text-muted">
                                             <?= date('M j, Y H:i', $fork['created_at']) ?> — <?= $fork['views'] ?> views


### PR DESCRIPTION
This pull request introduces enhancements to the paste creation and viewing functionalities, focusing on user attribution, guest pasting, and visual improvements. The most important changes include adding support for associating pastes with user accounts, enabling anonymous pasting for logged-in users, and improving the display of user avatars and usernames in the paste view.

### Enhancements to paste creation:

* [`includes/db.php`](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L111-R116): Updated the `createPasteAdvanced` function to include a `userId` parameter, allowing pastes to be associated with user accounts. Modified the database query to insert the `user_id` field when creating a paste. [[1]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L111-R116) [[2]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L150-R156) [[3]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L167-R173)
* [`pages/create.php`](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cR32): Added a "Paste as guest" option in the paste creation form, allowing logged-in users to post anonymously. Updated logic to pass `userId` as `null` when the guest option is selected. [[1]](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cR32) [[2]](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cL70-R76) [[3]](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cR348-R354)

### Enhancements to paste viewing:

* [`includes/db.php`](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L74-R79): Updated the `getPasteById` function to include user information (`username` and `profile_image`) in the paste details by joining the `users` table.
* [`pages/view.php`](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L694-R698): Improved user attribution by displaying the username and profile image of the paste creator. Default avatars are used for anonymous users or missing profile images. [[1]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L694-R698) [[2]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L949-R953) [[3]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L980-R984)Avatar images now fall back to the existing SVG when a user has no profile picture

The paste view shows the author’s avatar and username, defaulting to Anonymous with the SVG icon if no user is associated

Logged-in users can choose “Paste as a guest,” which omits their user ID when creating the paste

The create page’s advanced options include a checkbox for guest mode posting