### PR TITLE
Add profile page and dropdown link

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -90,6 +90,11 @@ if (isset($_SESSION['user_id'])) {
                                     <i class="fas fa-user-edit me-2"></i>Edit Profile
                                 </a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="/profile/profile.php">
+                                    <i class="fa fa-user"></i> Edit Profile
+                                </a>
+                            </li>
                         </ul>
                     </li>
 <?php else: ?>
@@ -122,6 +127,11 @@ if (isset($_SESSION['user_id'])) {
                                 <li>
                                     <a class="dropdown-item" href="/profile/edit_profile.php">
                                         <i class="fas fa-user-edit me-2"></i>Edit Profile
+                                    </a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item" href="/profile/profile.php">
+                                        <i class="fa fa-user"></i> Edit Profile
                                     </a>
                                 </li>
                             </ul>

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -1,0 +1,20 @@
+<?php
+include('../include/config.php');
+include('../include/session.php');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Profile</title>
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+    <?php include('../include/navbar.php'); ?>
+    <div class="container">
+        <h1><i class="fa fa-user"></i> User Profile</h1>
+        <p>This page is under construction.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a placeholder `profile/profile.php` page for user profile
- link new profile page in both desktop and mobile dropdown menus

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aca8e398c83219eb03b1c4104c873