### PR TITLE
Add profile page and dropdown link

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -90,6 +90,11 @@ if (isset($_SESSION['user_id'])) {
                                     <i class="fas fa-user-edit me-2"></i>Edit Profile
                                 </a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="/profile/profile.php">
+                                    <i class="fas fa-user me-2"></i>View Profile
+                                </a>
+                            </li>
                         </ul>
                     </li>
 <?php else: ?>
@@ -119,11 +124,16 @@ if (isset($_SESSION['user_id'])) {
                                 <span><?php echo htmlspecialchars($userData['username']); ?></span>
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
-                                <li>
-                                    <a class="dropdown-item" href="/profile/edit_profile.php">
-                                        <i class="fas fa-user-edit me-2"></i>Edit Profile
-                                    </a>
-                                </li>
+                            <li>
+                                <a class="dropdown-item" href="/profile/edit_profile.php">
+                                    <i class="fas fa-user-edit me-2"></i>Edit Profile
+                                </a>
+                            </li>
+                            <li>
+                                <a class="dropdown-item" href="/profile/profile.php">
+                                    <i class="fas fa-user me-2"></i>View Profile
+                                </a>
+                            </li>
                             </ul>
                         </div>
 <?php else: ?>

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -1,0 +1,23 @@
+<?php
+session_start();
+require_once '../includes/db.php';
+require_once '../database/init.php';
+
+$pageTitle = 'User Profile';
+include '../includes/header.php';
+?>
+<main class="container-fluid px-4 py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+            <div class="card border-0 shadow-lg">
+                <div class="card-header border-0 text-white py-3" style="background-color: #334155;">
+                    <h4 class="mb-0"><i class="fas fa-user me-2"></i>User Profile</h4>
+                </div>
+                <div class="card-body p-4">
+                    <p>This page is under construction.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+<?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add a placeholder `profile/profile.php` page for user profile
- link new profile page in both desktop and mobile dropdown menus

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aca8e398c83219eb03b1c4104c873