### PR TITLE
Fix profile dropdown menu label

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -92,7 +92,7 @@ if (isset($_SESSION['user_id'])) {
                             </li>
                             <li>
                                 <a class="dropdown-item" href="/profile/profile.php">
-                                    <i class="fa fa-user"></i> Edit Profile
+                                    <i class="fa fa-user"></i> View Profile
                                 </a>
                             </li>
                         </ul>
@@ -131,7 +131,7 @@ if (isset($_SESSION['user_id'])) {
                                 </li>
                                 <li>
                                     <a class="dropdown-item" href="/profile/profile.php">
-                                        <i class="fa fa-user"></i> Edit Profile
+                                        <i class="fa fa-user"></i> View Profile
                                     </a>
                                 </li>
                             </ul>


### PR DESCRIPTION
## Summary
- fix duplicate label in the profile dropdown menus
- second item now shows **View Profile** with the correct icon

## Testing
- `php -l includes/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ace7e0c9c832186647e34bf470159