### PR TITLE
Fix profile tab layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,13 @@ input.burn-link-input:focus,
     color: white !important;  /* White text for contrast on dark background */
 }
 
+@media (min-width: 768px) {
+    #profileTabs {
+        flex-wrap: nowrap;
+        gap: 0.5rem;
+    }
+}
+
 /* Enhanced Form Controls */
 .form-control, .form-select, textarea {
     background: var(--card-bg-light);

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -74,7 +74,7 @@ include __DIR__ . '/../includes/header.php';
             </div>
             <div class="card border-0 shadow-sm">
                 <div class="card-header bg-transparent border-0 p-0">
-                    <ul class="nav nav-tabs border-0" id="profileTabs" role="tablist">
+                    <ul class="nav nav-tabs border-0 nav-fill flex-nowrap gap-2" id="profileTabs" role="tablist">
                         <li class="nav-item" role="presentation">
                             <button class="nav-link active border-0 fw-semibold" id="overview-tab" data-bs-toggle="tab" data-bs-target="#overview" type="button" role="tab">
                                 <i class="fas fa-chart-bar me-2"></i>Overview


### PR DESCRIPTION
## Summary
- prevent wrapping of profile tabs on large screens
- style profile tabs container for consistent spacing

## Testing
- `composer install` *(fails: command not found)*
- `php -l` on all PHP files *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b195b149c8321a7213a0ee925a54f