### PR TITLE
Fix/profile tabs layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,6 +303,13 @@ input.burn-link-input:focus,
     color: white !important;  /* White text for contrast on dark background */
 }
 
+@media (min-width: 768px) {
+    #profileTabs {
+        flex-wrap: nowrap;
+        gap: 0.5rem;
+    }
+}
+
 /* Enhanced Form Controls */
 .form-control, .form-select, textarea {
     background: var(--card-bg-light);

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -74,7 +74,7 @@ include __DIR__ . '/../includes/header.php';
             </div>
             <div class="card border-0 shadow-sm">
                 <div class="card-header bg-transparent border-0 p-0">
-                    <ul class="nav nav-tabs border-0" id="profileTabs" role="tablist">
+                    <ul class="nav nav-tabs border-0 nav-fill flex-nowrap gap-2" id="profileTabs" role="tablist">
                         <li class="nav-item" role="presentation">
                             <button class="nav-link active border-0 fw-semibold" id="overview-tab" data-bs-toggle="tab" data-bs-target="#overview" type="button" role="tab">
                                 <i class="fas fa-chart-bar me-2"></i>Overview


### PR DESCRIPTION
This pull request introduces responsive design improvements to the profile tabs and refines their layout for better usability. The changes ensure consistent spacing and alignment across different screen sizes.

### Responsive design improvements:

* [`assets/css/style.css`](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeR306-R312): Added a media query to ensure the `#profileTabs` element does not wrap and maintains consistent spacing (`gap: 0.5rem`) on screens wider than 768px.

### Layout refinements:

* [`profile/profile.php`](diffhunk://#diff-e1c3b1ccbae28a017a7e4dd9779e54562ad45d0ab13c207071720c34e64542d1L77-R77): Updated the `#profileTabs` element to use `flex-nowrap` and `gap-2`, enhancing the layout by ensuring tabs are aligned and spaced evenly.