### PR TITLE
Add data-driven charts to profile overview

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2011,4 +2011,10 @@ button[disabled] {
     border: 2px solid var(--border-color);
     border-radius: var(--border-radius);
     padding: 1rem;
+    position: relative;
+}
+
+.profile-chart canvas {
+    width: 100% !important;
+    height: 100% !important;
 }


### PR DESCRIPTION
## Summary
- query stats for pastes to populate charts
- add responsive charts for past week of pastes and engagement totals
- tweak CSS so chart containers fill available space

## Testing
- `php -l profile/profile.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b2cab35a48321845e7c4dda725293