### PR TITLE
Fix chart colors in dark mode

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,7 +33,8 @@ class ThemeManager {
         this.theme = this.theme === 'dark' ? 'light' : 'dark';
         localStorage.setItem('theme', this.theme);
         this.applyTheme();
-        
+        document.dispatchEvent(new CustomEvent('themeChanged', { detail: this.theme }));
+
         // Add smooth transition effect
         document.body.style.transition = 'background-color 0.3s ease, color 0.3s ease';
         setTimeout(() => {

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -216,8 +216,14 @@ include __DIR__ . '/../includes/header.php';
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    const getTextColor = () => {
+        const isDarkMode = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+        return isDarkMode ? '#f0f0f0' : '#333';
+    };
+    let textColor = getTextColor();
+
     const ctx1 = document.getElementById('chart1').getContext('2d');
-    new Chart(ctx1, {
+    const chart1 = new Chart(ctx1, {
         type: 'bar',
         data: {
             labels: <?= json_encode($chart1Labels) ?>,
@@ -230,12 +236,19 @@ document.addEventListener('DOMContentLoaded', function () {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { title: { display: true, text: 'Pastes Created Per Day' } }
+            plugins: {
+                title: { display: true, text: 'Pastes Created Per Day', color: textColor },
+                legend: { labels: { color: textColor } }
+            },
+            scales: {
+                x: { ticks: { color: textColor } },
+                y: { ticks: { color: textColor } }
+            }
         }
     });
 
     const ctx2 = document.getElementById('chart2').getContext('2d');
-    new Chart(ctx2, {
+    const chart2 = new Chart(ctx2, {
         type: 'bar',
         data: {
             labels: <?= json_encode($chart2Labels) ?>,
@@ -248,8 +261,26 @@ document.addEventListener('DOMContentLoaded', function () {
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: { title: { display: true, text: 'Engagement Metrics' } }
+            plugins: {
+                title: { display: true, text: 'Engagement Metrics', color: textColor },
+                legend: { labels: { color: textColor } }
+            },
+            scales: {
+                x: { ticks: { color: textColor } },
+                y: { ticks: { color: textColor } }
+            }
         }
+    });
+
+    document.addEventListener('themeChanged', () => {
+        textColor = getTextColor();
+        [chart1, chart2].forEach(chart => {
+            chart.options.plugins.title.color = textColor;
+            chart.options.plugins.legend.labels.color = textColor;
+            chart.options.scales.x.ticks.color = textColor;
+            chart.options.scales.y.ticks.color = textColor;
+            chart.update();
+        });
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- adjust chart options in `profile.php` to use dynamic colors
- dispatch `themeChanged` events when toggling themes

## Testing
- `node -c assets/js/app.js`
- *(testing PHP files skipped: php command not available)*

------
https://chatgpt.com/codex/tasks/task_e_686b567ba73083218e67ea75e340fa12