### PR TITLE
Implement achievements system

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1996,6 +1996,9 @@ button[disabled] {
     padding: 1rem;
     text-align: center;
 }
+[data-bs-theme="dark"] .progress {
+    background-color: #2d3748;
+}
 [data-bs-theme="dark"] .profile-stat {
     background: linear-gradient(to bottom right, rgba(99,102,241,0.2), rgba(59,130,246,0.1));
 }

--- a/database/achievements.csv
+++ b/database/achievements.csv
@@ -1,0 +1,4 @@
+name,category,description,target_progress,points,icon
+First Paste,General,Create your first paste,1,10,fa-file-alt
+Popular,Views,Reach 100 views on a paste,100,20,fa-fire
+Contributor,Engagement,Fork 5 pastes,5,15,fa-code-branch

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -326,4 +326,36 @@ CREATE INDEX IF NOT EXISTS "idx_pastes_language" ON "pastes" ("language");
 CREATE INDEX IF NOT EXISTS "idx_paste_views_paste_id" ON "paste_views" ("paste_id");
 CREATE INDEX IF NOT EXISTS "idx_paste_views_ip_address" ON "paste_views" ("ip_address");
 
+-- Achievements system tables
+CREATE TABLE IF NOT EXISTS "achievements" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL UNIQUE,
+    "category" TEXT,
+    "description" TEXT,
+    "target_progress" INTEGER DEFAULT 1,
+    "points" INTEGER DEFAULT 0,
+    "icon" TEXT DEFAULT 'fa-trophy'
+);
+
+CREATE TABLE IF NOT EXISTS "user_achievement_progress" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "user_id" TEXT NOT NULL,
+    "achievement_id" INTEGER NOT NULL,
+    "current_progress" INTEGER DEFAULT 0,
+    "target_progress" INTEGER NOT NULL,
+    "updated_at" INTEGER DEFAULT (strftime('%s','now')),
+    FOREIGN KEY("achievement_id") REFERENCES "achievements"("id"),
+    FOREIGN KEY("user_id") REFERENCES "users"("id")
+);
+
+CREATE TABLE IF NOT EXISTS "user_achievements" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "user_id" TEXT NOT NULL,
+    "achievement_id" INTEGER NOT NULL,
+    "unlocked_at" INTEGER DEFAULT (strftime('%s','now')),
+    "points" INTEGER DEFAULT 0,
+    FOREIGN KEY("achievement_id") REFERENCES "achievements"("id"),
+    FOREIGN KEY("user_id") REFERENCES "users"("id")
+);
+
 COMMIT;

--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -1,0 +1,111 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+/**
+ * Load achievements from a CSV file into the achievements table.
+ */
+function loadAchievementsFromCSV($csvPath)
+{
+    global $pdo;
+    if (!file_exists($csvPath)) {
+        return;
+    }
+    if (($handle = fopen($csvPath, 'r')) === false) {
+        return;
+    }
+    $header = fgetcsv($handle);
+    if (!$header) {
+        fclose($handle);
+        return;
+    }
+    $insert = $pdo->prepare('INSERT OR IGNORE INTO achievements (name, category, description, target_progress, points, icon) VALUES (?, ?, ?, ?, ?, ?)');
+    while (($row = fgetcsv($handle)) !== false) {
+        $data = array_combine($header, $row);
+        $insert->execute([
+            $data['name'],
+            $data['category'] ?? null,
+            $data['description'] ?? null,
+            (int)($data['target_progress'] ?? 1),
+            (int)($data['points'] ?? 0),
+            $data['icon'] ?? 'fa-trophy'
+        ]);
+    }
+    fclose($handle);
+}
+
+/**
+ * Increment progress for a user's achievement and unlock if completed.
+ */
+function updateAchievementProgress($userId, $achievementName, $increment = 1)
+{
+    global $pdo;
+    $achStmt = $pdo->prepare('SELECT id, target_progress, points FROM achievements WHERE name = ?');
+    $achStmt->execute([$achievementName]);
+    $achievement = $achStmt->fetch();
+    if (!$achievement) {
+        return;
+    }
+    // already unlocked?
+    $check = $pdo->prepare('SELECT 1 FROM user_achievements WHERE user_id = ? AND achievement_id = ?');
+    $check->execute([$userId, $achievement['id']]);
+    if ($check->fetchColumn()) {
+        return;
+    }
+    $progStmt = $pdo->prepare('SELECT id, current_progress FROM user_achievement_progress WHERE user_id = ? AND achievement_id = ?');
+    $progStmt->execute([$userId, $achievement['id']]);
+    $progress = $progStmt->fetch();
+    if ($progress) {
+        $newProgress = $progress['current_progress'] + $increment;
+        $pdo->prepare('UPDATE user_achievement_progress SET current_progress = ?, updated_at = strftime(\'%s\',\'now\') WHERE id = ?')
+            ->execute([$newProgress, $progress['id']]);
+    } else {
+        $pdo->prepare('INSERT INTO user_achievement_progress (user_id, achievement_id, current_progress, target_progress) VALUES (?, ?, ?, ?)')
+            ->execute([$userId, $achievement['id'], $increment, $achievement['target_progress']]);
+        $newProgress = $increment;
+    }
+    if ($newProgress >= $achievement['target_progress']) {
+        $pdo->prepare('DELETE FROM user_achievement_progress WHERE user_id = ? AND achievement_id = ?')
+            ->execute([$userId, $achievement['id']]);
+        $pdo->prepare('INSERT INTO user_achievements (user_id, achievement_id, points) VALUES (?, ?, ?)')
+            ->execute([$userId, $achievement['id'], $achievement['points']]);
+    }
+}
+
+/**
+ * Get achievement summary statistics for a user.
+ */
+function getUserAchievementStats($userId)
+{
+    global $pdo;
+    $totalUnlocked = (int)$pdo->query("SELECT COUNT(*) FROM user_achievements WHERE user_id = '" . $userId . "'")->fetchColumn();
+    $totalPoints = (int)$pdo->query("SELECT COALESCE(SUM(points),0) FROM user_achievements WHERE user_id = '" . $userId . "'")->fetchColumn();
+    $totalAchievements = (int)$pdo->query('SELECT COUNT(*) FROM achievements')->fetchColumn();
+    $completionRate = $totalAchievements > 0 ? round(($totalUnlocked / $totalAchievements) * 100) : 0;
+    return [
+        'unlocked' => $totalUnlocked,
+        'points' => $totalPoints,
+        'completion' => $completionRate
+    ];
+}
+
+/**
+ * Get list of unlocked achievements for a user.
+ */
+function getUnlockedAchievements($userId)
+{
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT a.name, a.description, a.icon, ua.unlocked_at, a.points FROM user_achievements ua JOIN achievements a ON ua.achievement_id = a.id WHERE ua.user_id = ? ORDER BY ua.unlocked_at DESC');
+    $stmt->execute([$userId]);
+    return $stmt->fetchAll();
+}
+
+/**
+ * Get list of achievements still in progress for a user.
+ */
+function getInProgressAchievements($userId)
+{
+    global $pdo;
+    $stmt = $pdo->prepare('SELECT a.name, a.description, a.icon, uap.current_progress, uap.target_progress FROM user_achievement_progress uap JOIN achievements a ON uap.achievement_id = a.id WHERE uap.user_id = ? ORDER BY uap.updated_at DESC');
+    $stmt->execute([$userId]);
+    return $stmt->fetchAll();
+}

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -4,6 +4,8 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../database/init.php';
+require_once __DIR__ . '/../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 
 $identifier = $_GET['uid'] ?? ($_SESSION['user_id'] ?? null);
 if (!$identifier) {
@@ -110,6 +112,10 @@ $chart2Values = [
     $totalComments
 ];
 
+$achievementStats = getUserAchievementStats($user['id']);
+$unlockedAchievements = getUnlockedAchievements($user['id']);
+$inProgressAchievements = getInProgressAchievements($user['id']);
+
 $pageTitle = htmlspecialchars($user['username']);
 include __DIR__ . '/../includes/header.php';
 ?>
@@ -202,7 +208,69 @@ include __DIR__ . '/../includes/header.php';
                 </div>
             </div>
             <div class="tab-pane fade" id="achievements" role="tabpanel">
-                <p class="text-muted">Coming soon...</p>
+                <div class="row g-3 mb-4">
+                    <div class="col-md-4">
+                        <div class="profile-stat">
+                            <i class="fas fa-trophy mb-1"></i>
+                            <div class="h5 mb-0"><?= $achievementStats['unlocked'] ?></div>
+                            <small class="text-muted">Achievements Unlocked</small>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="profile-stat">
+                            <i class="fas fa-percentage mb-1"></i>
+                            <div class="h5 mb-0"><?= $achievementStats['completion'] ?>%</div>
+                            <small class="text-muted">Completion Rate</small>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="profile-stat">
+                            <i class="fas fa-star mb-1"></i>
+                            <div class="h5 mb-0"><?= $achievementStats['points'] ?></div>
+                            <small class="text-muted">Total Points</small>
+                        </div>
+                    </div>
+                </div>
+
+                <h5 class="mb-3">Unlocked Achievements</h5>
+                <div class="row g-3 mb-4">
+                    <?php foreach ($unlockedAchievements as $a): ?>
+                    <div class="col-md-4">
+                        <div class="card h-100 text-center">
+                            <div class="card-body">
+                                <i class="fas <?= htmlspecialchars($a['icon']) ?> fa-2x mb-2 text-warning"></i>
+                                <h6 class="card-title mb-1"><?= htmlspecialchars($a['name']) ?></h6>
+                                <p class="small text-muted mb-2"><?= htmlspecialchars($a['description']) ?></p>
+                                <span class="badge bg-success">Unlocked <?= date('Y-m-d', $a['unlocked_at']) ?></span>
+                            </div>
+                        </div>
+                    </div>
+                    <?php endforeach; ?>
+                    <?php if (empty($unlockedAchievements)): ?>
+                        <p class="text-muted">No achievements unlocked yet.</p>
+                    <?php endif; ?>
+                </div>
+
+                <h5 class="mb-3">In Progress</h5>
+                <?php foreach ($inProgressAchievements as $a): ?>
+                <?php $percent = round(($a['current_progress'] / $a['target_progress']) * 100); ?>
+                <div class="mb-3">
+                    <div class="d-flex align-items-center mb-1">
+                        <i class="fas <?= htmlspecialchars($a['icon']) ?> me-2 text-warning"></i>
+                        <div class="flex-grow-1">
+                            <strong><?= htmlspecialchars($a['name']) ?></strong>
+                            <div class="small text-muted"><?= htmlspecialchars($a['description']) ?></div>
+                        </div>
+                        <span class="ms-2 small"><?= $percent ?>%</span>
+                    </div>
+                    <div class="progress" style="height:8px;">
+                        <div class="progress-bar" role="progressbar" style="width: <?= $percent ?>%;" aria-valuenow="<?= $percent ?>" aria-valuemin="0" aria-valuemax="100"></div>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+                <?php if (empty($inProgressAchievements)): ?>
+                    <p class="text-muted">No achievements in progress.</p>
+                <?php endif; ?>
             </div>
             <div class="tab-pane fade" id="collections" role="tabpanel">
                 <p class="text-muted">Coming soon...</p>


### PR DESCRIPTION
## Summary
- define achievements tables in schema
- provide seed achievements CSV
- add achievement helper functions
- integrate achievements tab in profile page
- tweak style for progress bars

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1464f86c8321b92a923c2d221a2a