### PR TITLE
Add migration system for achievements

### DIFF
--- a/database/migrations/001_add_achievements_tables.php
+++ b/database/migrations/001_add_achievements_tables.php
@@ -1,0 +1,54 @@
+<?php
+return function (PDO $pdo) {
+    // Fetch existing table names
+    $tables = $pdo->query("SELECT name FROM sqlite_master WHERE type='table'")->fetchAll(PDO::FETCH_COLUMN);
+
+    if (!in_array('achievements', $tables)) {
+        $pdo->exec(<<<SQL
+CREATE TABLE achievements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    icon TEXT NOT NULL,
+    category TEXT DEFAULT 'general',
+    points INTEGER DEFAULT 10,
+    is_active BOOLEAN DEFAULT 1,
+    created_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+SQL
+        );
+    }
+
+    if (!in_array('user_achievement_progress', $tables)) {
+        $pdo->exec(<<<SQL
+CREATE TABLE user_achievement_progress (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    achievement_name TEXT NOT NULL,
+    current_progress INTEGER DEFAULT 0,
+    target_progress INTEGER NOT NULL,
+    last_updated INTEGER DEFAULT (strftime('%s', 'now')),
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    UNIQUE(user_id, achievement_name)
+);
+SQL
+        );
+    }
+
+    if (!in_array('user_achievements', $tables)) {
+        $pdo->exec(<<<SQL
+CREATE TABLE user_achievements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    achievement_id INTEGER NOT NULL,
+    unlocked_at INTEGER DEFAULT (strftime('%s', 'now')),
+    progress_data TEXT,
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(achievement_id) REFERENCES achievements(id),
+    UNIQUE(user_id, achievement_id)
+);
+SQL
+        );
+    }
+};

--- a/database/run_migrations.php
+++ b/database/run_migrations.php
@@ -1,0 +1,43 @@
+<?php
+function runMigrations(PDO $pdo) {
+    $migrationDir = __DIR__ . '/migrations';
+
+    // Ensure migration log table exists
+    $pdo->exec(<<<SQL
+CREATE TABLE IF NOT EXISTS migration_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    filename TEXT NOT NULL UNIQUE,
+    applied_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+SQL
+    );
+
+    if (!is_dir($migrationDir)) {
+        return;
+    }
+
+    $files = glob($migrationDir . '/*.php');
+    sort($files);
+
+    foreach ($files as $file) {
+        $name = basename($file);
+        $stmt = $pdo->prepare('SELECT 1 FROM migration_log WHERE filename = ?');
+        $stmt->execute([$name]);
+        if ($stmt->fetchColumn()) {
+            continue;
+        }
+
+        $migration = include $file;
+        if (is_callable($migration)) {
+            $migration($pdo);
+        }
+
+        $insert = $pdo->prepare('INSERT INTO migration_log (filename) VALUES (?)');
+        $insert->execute([$name]);
+    }
+}
+
+if (basename(__FILE__) === basename($_SERVER['PHP_SELF'])) {
+    require_once __DIR__ . '/../includes/db.php';
+    runMigrations($pdo);
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -28,7 +28,11 @@ function getDatabase() {
             require_once __DIR__ . '/../database/init.php';
             initializeDatabase($pdo);
         }
-        
+
+        // Run any pending database migrations
+        require_once __DIR__ . '/../database/run_migrations.php';
+        runMigrations($pdo);
+
         return $pdo;
     } catch (PDOException $e) {
         die("Database connection failed: " . $e->getMessage());


### PR DESCRIPTION
## Summary
- add migration for achievements tables
- create migration runner
- hook migrations into database connection

## Testing
- `php -l database/migrations/001_add_achievements_tables.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1ef25f288321a4afdddb57bc4e32