### PR TITLE
Fix achievements schema and total points query

### DIFF
--- a/database/migrations/001_add_achievements_tables.php
+++ b/database/migrations/001_add_achievements_tables.php
@@ -13,11 +13,20 @@ CREATE TABLE achievements (
     icon TEXT NOT NULL,
     category TEXT DEFAULT 'general',
     points INTEGER DEFAULT 10,
+    target_progress INTEGER DEFAULT 1,
     is_active BOOLEAN DEFAULT 1,
     created_at INTEGER DEFAULT (strftime('%s', 'now'))
 );
 SQL
         );
+    } else {
+        $cols = $pdo->query("PRAGMA table_info(achievements)")->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('target_progress', $cols)) {
+            $pdo->exec("ALTER TABLE achievements ADD COLUMN target_progress INTEGER DEFAULT 1");
+        }
+        if (!in_array('points', $cols)) {
+            $pdo->exec("ALTER TABLE achievements ADD COLUMN points INTEGER DEFAULT 10");
+        }
     }
 
     if (!in_array('user_achievement_progress', $tables)) {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -330,11 +330,14 @@ CREATE INDEX IF NOT EXISTS "idx_paste_views_ip_address" ON "paste_views" ("ip_ad
 CREATE TABLE IF NOT EXISTS "achievements" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "name" TEXT NOT NULL UNIQUE,
-    "category" TEXT,
-    "description" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "icon" TEXT NOT NULL,
+    "category" TEXT DEFAULT 'general',
+    "points" INTEGER DEFAULT 10,
     "target_progress" INTEGER DEFAULT 1,
-    "points" INTEGER DEFAULT 0,
-    "icon" TEXT DEFAULT 'fa-trophy'
+    "is_active" BOOLEAN DEFAULT 1,
+    "created_at" INTEGER DEFAULT (strftime('%s', 'now'))
 );
 
 CREATE TABLE IF NOT EXISTS "user_achievement_progress" (

--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -78,7 +78,12 @@ function getUserAchievementStats($userId)
 {
     global $pdo;
     $totalUnlocked = (int)$pdo->query("SELECT COUNT(*) FROM user_achievements WHERE user_id = '" . $userId . "'")->fetchColumn();
-    $totalPoints = (int)$pdo->query("SELECT COALESCE(SUM(points),0) FROM user_achievements WHERE user_id = '" . $userId . "'")->fetchColumn();
+    $totalPoints = (int)$pdo->query(
+        "SELECT COALESCE(SUM(a.points), 0)
+         FROM user_achievements ua
+         JOIN achievements a ON ua.achievement_id = a.id
+         WHERE ua.user_id = '" . $userId . "'"
+    )->fetchColumn();
     $totalAchievements = (int)$pdo->query('SELECT COUNT(*) FROM achievements')->fetchColumn();
     $completionRate = $totalAchievements > 0 ? round(($totalUnlocked / $totalAchievements) * 100) : 0;
     return [


### PR DESCRIPTION
## Summary
- define missing columns in achievements schema
- sum achievement points by joining to achievements table
- ensure migration adds `target_progress` and `points` columns if needed

## Testing
- `php -l includes/achievements.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2835ea348321a535c58154b66e03