### PR TITLE
Fix achievements progress join

### DIFF
--- a/database/migrations/002_add_achievement_id_to_progress.php
+++ b/database/migrations/002_add_achievement_id_to_progress.php
@@ -1,0 +1,20 @@
+<?php
+return function (PDO $pdo) {
+    // Check existing columns in user_achievement_progress
+    $cols = $pdo->query("PRAGMA table_info(user_achievement_progress)")->fetchAll(PDO::FETCH_COLUMN, 1);
+
+    if (!in_array('achievement_id', $cols)) {
+        // Add the missing achievement_id column
+        $pdo->exec("ALTER TABLE user_achievement_progress ADD COLUMN achievement_id INTEGER");
+
+        // Populate achievement_id by matching on achievement_name
+        $pdo->exec(
+            "UPDATE user_achievement_progress
+             SET achievement_id = (
+                 SELECT id FROM achievements WHERE name = user_achievement_progress.achievement_name
+             )
+             WHERE achievement_id IS NULL"
+        );
+    }
+};
+

--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -110,7 +110,13 @@ function getUnlockedAchievements($userId)
 function getInProgressAchievements($userId)
 {
     global $pdo;
-    $stmt = $pdo->prepare('SELECT a.name, a.description, a.icon, uap.current_progress, uap.target_progress FROM user_achievement_progress uap JOIN achievements a ON uap.achievement_id = a.id WHERE uap.user_id = ? ORDER BY uap.updated_at DESC');
-    $stmt->execute([$userId]);
+    $stmt = $pdo->prepare(
+        "SELECT a.name, a.description, a.icon, uap.current_progress, uap.target_progress
+         FROM user_achievement_progress uap
+         JOIN achievements a ON uap.achievement_id = a.id
+         WHERE uap.user_id = :user_id
+         ORDER BY uap.updated_at DESC"
+    );
+    $stmt->execute(['user_id' => $userId]);
     return $stmt->fetchAll();
 }


### PR DESCRIPTION
## Summary
- add migration to create `achievement_id` in `user_achievement_progress`
- update achievements query to use named parameter

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*
- `php -l includes/achievements.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2b6ea82c832182296f5bf963fa68