### PR TITLE
Fix achievement tracking and display

### DIFF
--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -18,11 +18,12 @@ function loadAchievementsFromCSV($csvPath)
         fclose($handle);
         return;
     }
-    $insert = $pdo->prepare('INSERT OR IGNORE INTO achievements (name, category, description, target_progress, points, icon) VALUES (?, ?, ?, ?, ?, ?)');
+    $insert = $pdo->prepare('INSERT OR IGNORE INTO achievements (name, title, category, description, target_progress, points, icon) VALUES (?, ?, ?, ?, ?, ?, ?)');
     while (($row = fgetcsv($handle)) !== false) {
         $data = array_combine($header, $row);
         $insert->execute([
             $data['name'],
+            $data['title'] ?? $data['name'],
             $data['category'] ?? null,
             $data['description'] ?? null,
             (int)($data['target_progress'] ?? 1),

--- a/pages/create.php
+++ b/pages/create.php
@@ -2,6 +2,8 @@
 session_start();
 require_once '../includes/db.php';
 require_once '../database/init.php';
+require_once '../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 $success = false;
 $error = '';
 $pasteId = '';
@@ -105,10 +107,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $userId = $_SESSION['user_id'];
                     $stmt = $pdo->prepare("INSERT INTO paste_forks (original_paste_id, forked_paste_id, forked_by_user_id) VALUES (?, ?, ?)");
                     $stmt->execute([$forkOriginalId, $pasteId, $userId]);
+                    updateAchievementProgress($userId, 'Contributor');
                 } else {
                     $stmt = $pdo->prepare("INSERT INTO paste_forks (original_paste_id, forked_paste_id) VALUES (?, ?)");
                     $stmt->execute([$forkOriginalId, $pasteId]);
                 }
+            }
+
+            if ($userId) {
+                updateAchievementProgress($userId, 'First Paste');
             }
             
             // For burn after read pastes, add secure creator token

--- a/pages/view.php
+++ b/pages/view.php
@@ -8,6 +8,8 @@ set_time_limit(120);
 session_start();
 require_once '../includes/db.php';
 require_once '../database/init.php';
+require_once '../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 
 $pasteId = $_GET['id'] ?? '';
 $viewThread = $_GET['view_thread'] ?? '';
@@ -152,19 +154,25 @@ if (empty($pasteId)) {
                     // This is a real view - check if paste should be burned
                     if (shouldBurnPaste($pasteId)) {
                         // Increment view count first, then burn the paste
-                        incrementViewCount($pasteId, $userIP);
+                        if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                            updateAchievementProgress($paste['user_id'], 'Popular');
+                        }
                         burnPaste($pasteId);
                         
                         // Show burn notification
                         $burnNotification = true;
                     } else {
                         // Not ready to burn yet
-                        incrementViewCount($pasteId, $userIP);
+                        if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                            updateAchievementProgress($paste['user_id'], 'Popular');
+                        }
                     }
                 }
             } else {
                 // Normal paste - increment view count
-                incrementViewCount($pasteId, $userIP);
+                if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                    updateAchievementProgress($paste['user_id'], 'Popular');
+                }
             }
             
             // Count lines in the paste content for proper line number generation

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -316,6 +316,7 @@ include __DIR__ . '/../includes/header.php';
                     <div class="progress" style="height:8px;">
                         <div class="progress-bar" role="progressbar" style="width: <?= $percent ?>%;" aria-valuenow="<?= $percent ?>" aria-valuemin="0" aria-valuemax="100"></div>
                     </div>
+                    <div class="small text-muted mt-1"><?= $a['current_progress'] ?>/<?= $a['target_progress'] ?></div>
                 </div>
                 <?php endforeach; ?>
                 <?php if (empty($inProgressAchievements)): ?>


### PR DESCRIPTION
## Summary
- ensure CSV loader inserts title column
- load achievements where needed
- award achievements when creating pastes or forking
- track view-based progress
- show numeric progress in profile

## Testing
- `php` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_686d5c262da88321a2ab59ff32199ad2