### PR TITLE
Fix progress insert missing achievement name

### DIFF
--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -60,8 +60,12 @@ function updateAchievementProgress($userId, $achievementName, $increment = 1)
         $pdo->prepare('UPDATE user_achievement_progress SET current_progress = ?, updated_at = strftime(\'%s\',\'now\') WHERE id = ?')
             ->execute([$newProgress, $progress['id']]);
     } else {
-        $pdo->prepare('INSERT INTO user_achievement_progress (user_id, achievement_id, current_progress, target_progress) VALUES (?, ?, ?, ?)')
-            ->execute([$userId, $achievement['id'], $increment, $achievement['target_progress']]);
+        if (empty($achievementName)) {
+            error_log('Achievement name missing when inserting progress for user ' . $userId);
+            return;
+        }
+        $pdo->prepare('INSERT INTO user_achievement_progress (user_id, achievement_id, achievement_name, current_progress, target_progress) VALUES (?, ?, ?, ?, ?)')
+            ->execute([$userId, $achievement['id'], $achievementName, $increment, $achievement['target_progress']]);
         $newProgress = $increment;
     }
     if ($newProgress >= $achievement['target_progress']) {


### PR DESCRIPTION
## Summary
- fix NOT NULL constraint error by including achievement_name in INSERT
- log an error when achievement name is empty

## Testing
- `php -l includes/achievements.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f1f68b48321bf8d8229edd9a9c5