### PR TITLE
Fix missing column in user achievements insert

### DIFF
--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -71,8 +71,10 @@ function updateAchievementProgress($userId, $achievementName, $increment = 1)
     if ($newProgress >= $achievement['target_progress']) {
         $pdo->prepare('DELETE FROM user_achievement_progress WHERE user_id = ? AND achievement_id = ?')
             ->execute([$userId, $achievement['id']]);
-        $pdo->prepare('INSERT INTO user_achievements (user_id, achievement_id, points) VALUES (?, ?, ?)')
-            ->execute([$userId, $achievement['id'], $achievement['points']]);
+        // user_achievements table does not store a points column
+        // Points are derived from the achievements table when needed
+        $pdo->prepare('INSERT INTO user_achievements (user_id, achievement_id) VALUES (?, ?)')
+            ->execute([$userId, $achievement['id']]);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove nonexistent `points` column from user achievements insertion

## Testing
- `php -l includes/achievements.php` *(fails: command not found)*
- `composer validate --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6071fe0c8321b4b08a88f50e69b5