### PR TITLE
Feature/fix achievements tracking

### DIFF
--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -71,8 +71,10 @@ function updateAchievementProgress($userId, $achievementName, $increment = 1)
     if ($newProgress >= $achievement['target_progress']) {
         $pdo->prepare('DELETE FROM user_achievement_progress WHERE user_id = ? AND achievement_id = ?')
             ->execute([$userId, $achievement['id']]);
-        $pdo->prepare('INSERT INTO user_achievements (user_id, achievement_id, points) VALUES (?, ?, ?)')
-            ->execute([$userId, $achievement['id'], $achievement['points']]);
+        // user_achievements table does not store a points column
+        // Points are derived from the achievements table when needed
+        $pdo->prepare('INSERT INTO user_achievements (user_id, achievement_id) VALUES (?, ?)')
+            ->execute([$userId, $achievement['id']]);
     }
 }
 

--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -18,11 +18,12 @@ function loadAchievementsFromCSV($csvPath)
         fclose($handle);
         return;
     }
-    $insert = $pdo->prepare('INSERT OR IGNORE INTO achievements (name, category, description, target_progress, points, icon) VALUES (?, ?, ?, ?, ?, ?)');
+    $insert = $pdo->prepare('INSERT OR IGNORE INTO achievements (name, title, category, description, target_progress, points, icon) VALUES (?, ?, ?, ?, ?, ?, ?)');
     while (($row = fgetcsv($handle)) !== false) {
         $data = array_combine($header, $row);
         $insert->execute([
             $data['name'],
+            $data['title'] ?? $data['name'],
             $data['category'] ?? null,
             $data['description'] ?? null,
             (int)($data['target_progress'] ?? 1),

--- a/includes/achievements.php
+++ b/includes/achievements.php
@@ -60,8 +60,12 @@ function updateAchievementProgress($userId, $achievementName, $increment = 1)
         $pdo->prepare('UPDATE user_achievement_progress SET current_progress = ?, updated_at = strftime(\'%s\',\'now\') WHERE id = ?')
             ->execute([$newProgress, $progress['id']]);
     } else {
-        $pdo->prepare('INSERT INTO user_achievement_progress (user_id, achievement_id, current_progress, target_progress) VALUES (?, ?, ?, ?)')
-            ->execute([$userId, $achievement['id'], $increment, $achievement['target_progress']]);
+        if (empty($achievementName)) {
+            error_log('Achievement name missing when inserting progress for user ' . $userId);
+            return;
+        }
+        $pdo->prepare('INSERT INTO user_achievement_progress (user_id, achievement_id, achievement_name, current_progress, target_progress) VALUES (?, ?, ?, ?, ?)')
+            ->execute([$userId, $achievement['id'], $achievementName, $increment, $achievement['target_progress']]);
         $newProgress = $increment;
     }
     if ($newProgress >= $achievement['target_progress']) {

--- a/pages/create.php
+++ b/pages/create.php
@@ -2,6 +2,8 @@
 session_start();
 require_once '../includes/db.php';
 require_once '../database/init.php';
+require_once '../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 $success = false;
 $error = '';
 $pasteId = '';
@@ -105,10 +107,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $userId = $_SESSION['user_id'];
                     $stmt = $pdo->prepare("INSERT INTO paste_forks (original_paste_id, forked_paste_id, forked_by_user_id) VALUES (?, ?, ?)");
                     $stmt->execute([$forkOriginalId, $pasteId, $userId]);
+                    updateAchievementProgress($userId, 'Contributor');
                 } else {
                     $stmt = $pdo->prepare("INSERT INTO paste_forks (original_paste_id, forked_paste_id) VALUES (?, ?)");
                     $stmt->execute([$forkOriginalId, $pasteId]);
                 }
+            }
+
+            if ($userId) {
+                updateAchievementProgress($userId, 'First Paste');
             }
             
             // For burn after read pastes, add secure creator token

--- a/pages/view.php
+++ b/pages/view.php
@@ -8,6 +8,8 @@ set_time_limit(120);
 session_start();
 require_once '../includes/db.php';
 require_once '../database/init.php';
+require_once '../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 
 $pasteId = $_GET['id'] ?? '';
 $viewThread = $_GET['view_thread'] ?? '';
@@ -152,19 +154,25 @@ if (empty($pasteId)) {
                     // This is a real view - check if paste should be burned
                     if (shouldBurnPaste($pasteId)) {
                         // Increment view count first, then burn the paste
-                        incrementViewCount($pasteId, $userIP);
+                        if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                            updateAchievementProgress($paste['user_id'], 'Popular');
+                        }
                         burnPaste($pasteId);
                         
                         // Show burn notification
                         $burnNotification = true;
                     } else {
                         // Not ready to burn yet
-                        incrementViewCount($pasteId, $userIP);
+                        if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                            updateAchievementProgress($paste['user_id'], 'Popular');
+                        }
                     }
                 }
             } else {
                 // Normal paste - increment view count
-                incrementViewCount($pasteId, $userIP);
+                if (incrementViewCount($pasteId, $userIP) && !empty($paste['user_id'])) {
+                    updateAchievementProgress($paste['user_id'], 'Popular');
+                }
             }
             
             // Count lines in the paste content for proper line number generation

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -29,11 +29,13 @@ if (!$user) {
 
 $avatar = $user['profile_image'] ? '/uploads/avatars/' . $user['profile_image'] : '/img/default-avatar.svg';
 
-// Number of pastes per page
+// Number of pastes to display per page
 $perPage = 5;
-// Current page from query param (default: 1)
+// Determine the requested page number
 $page = isset($_GET['page']) && is_numeric($_GET['page']) ? (int)$_GET['page'] : 1;
-$offset = ($page - 1) * $perPage;
+if ($page < 1) {
+    $page = 1;
+}
 
 $profile_user_id = $user['id'];
 $profile_username = $user['username'];
@@ -45,6 +47,10 @@ $countStmt = $pdo->prepare(
 $countStmt->execute([':uid' => $profile_user_id]);
 $totalPasteCount = (int)$countStmt->fetchColumn();
 $totalPages = (int)ceil($totalPasteCount / $perPage);
+if ($totalPages > 0 && $page > $totalPages) {
+    $page = $totalPages;
+}
+$offset = ($page - 1) * $perPage;
 
 // Fetch paginated pastes
 $stmt = $pdo->prepare(

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -316,6 +316,7 @@ include __DIR__ . '/../includes/header.php';
                     <div class="progress" style="height:8px;">
                         <div class="progress-bar" role="progressbar" style="width: <?= $percent ?>%;" aria-valuenow="<?= $percent ?>" aria-valuemin="0" aria-valuemax="100"></div>
                     </div>
+                    <div class="small text-muted mt-1"><?= $a['current_progress'] ?>/<?= $a['target_progress'] ?></div>
                 </div>
                 <?php endforeach; ?>
                 <?php if (empty($inProgressAchievements)): ?>

--- a/profile/profile.php
+++ b/profile/profile.php
@@ -68,7 +68,7 @@ function buildPageUrl($p) {
  */
 function fetchUserPastes(PDO $pdo, $uid, $limit, $offset) {
     $stmt = $pdo->prepare(
-        "SELECT id, title, created_at FROM pastes
+        "SELECT id, title, language, created_at FROM pastes
          WHERE user_id = :uid
          ORDER BY created_at DESC
          LIMIT :limit OFFSET :offset"
@@ -332,11 +332,16 @@ include __DIR__ . '/../includes/header.php';
     <?php foreach ($userPastes as $paste): ?>
     <div class="card mb-3 shadow-sm">
         <div class="card-body">
-            <h5 class="card-title">
-                <a href="/pages/view.php?id=<?php echo htmlspecialchars($paste['id']); ?>">
-                    <?php echo htmlspecialchars($paste['title'] ?: 'Untitled Paste'); ?>
-                </a>
-            </h5>
+            <div class="d-flex justify-content-between">
+                <h5 class="card-title mb-1">
+                    <a href="/pages/view.php?id=<?php echo htmlspecialchars($paste['id']); ?>">
+                        <?php echo htmlspecialchars($paste['title'] ?: 'Untitled Paste'); ?>
+                    </a>
+                </h5>
+                <span class="badge bg-secondary-subtle text-muted float-end align-self-start">
+                    <?php echo htmlspecialchars($paste['language']); ?>
+                </span>
+            </div>
             <p class="card-text text-muted mb-0">
                 <?php
                     $ts = is_numeric($paste['created_at']) ? $paste['created_at'] : strtotime($paste['created_at']);
@@ -446,6 +451,22 @@ document.addEventListener('DOMContentLoaded', function () {
             chart.update();
         });
     });
+});
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    function bindPastePagination() {
+        $('#pastes').off('click', '.pagination a').on('click', '.pagination a', function (e) {
+            e.preventDefault();
+            const url = $(this).attr('href');
+            $.get(url, function (data) {
+                const newContent = $(data).find('#pastes').html();
+                $('#pastes').html(newContent);
+                bindPastePagination();
+            });
+        });
+    }
+    bindPastePagination();
 });
 </script>
 <?php include __DIR__ . '/../includes/footer.php'; ?>


### PR DESCRIPTION
This pull request introduces enhancements to the achievements system, including support for a new `title` field in achievements, improved handling of achievement progress updates, integration of achievements into paste-related actions, and better user feedback on achievement progress. Below is a breakdown of the most significant changes:

### Achievements System Enhancements:

* **Support for `title` Field in Achievements:**
  - Updated the `loadAchievementsFromCSV` function to include a new `title` field when inserting achievements into the database. If `title` is missing, it defaults to the `name` field. (`includes/achievements.php`, [includes/achievements.phpL21-R26](diffhunk://#diff-fa44345ebd49dcdb88a3f0edece591bf5f8cfa42ae7e1006090851d4695d6f8eL21-R26))

* **Improved Achievement Progress Updates:**
  - Added validation to ensure `achievementName` is not empty before inserting progress, with error logging for missing names. Modified the `user_achievements` table to exclude the `points` column, as points are now derived dynamically from the `achievements` table. (`includes/achievements.php`, [includes/achievements.phpL62-R77](diffhunk://#diff-fa44345ebd49dcdb88a3f0edece591bf5f8cfa42ae7e1006090851d4695d6f8eL62-R77))

### Integration with Paste Actions:

* **Achievements Triggered by Paste Actions:**
  - Integrated `updateAchievementProgress` calls in `pages/create.php` to award achievements for actions like creating a first paste (`First Paste`) and contributing to a fork (`Contributor`). (`pages/create.php`, [pages/create.phpR110-R120](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cR110-R120))
  - Added achievement progress updates for popular pastes (`Popular`) based on view count increments in `pages/view.php`. (`pages/view.php`, [pages/view.phpL155-R175](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L155-R175))

### User Feedback Improvements:

* **Display Achievement Progress:**
  - Enhanced the profile page to display the current progress and target progress for achievements in a user-friendly format. (`profile/profile.php`, [profile/profile.phpR319](diffhunk://#diff-e1c3b1ccbae28a017a7e4dd9779e54562ad45d0ab13c207071720c34e64542d1R319))