### PR TITLE
Fix comment attribution for logged in users

### DIFF
--- a/api/helper.php
+++ b/api/helper.php
@@ -6,6 +6,11 @@
 
 header('Content-Type: application/json');
 require_once __DIR__ . '/../includes/db.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+require_once __DIR__ . '/../includes/achievements.php';
+loadAchievementsFromCSV(__DIR__ . '/../database/achievements.csv');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     echo json_encode(['success' => false, 'error' => 'Method not allowed']);
@@ -31,9 +36,13 @@ try {
             }
             
             // Add comment
-            $commentId = addComment($pasteId, $content, null);
+            $userId = $_SESSION['user_id'] ?? null;
+            $commentId = addComment($pasteId, $content, $userId);
             
             if ($commentId) {
+                if ($userId) {
+                    updateAchievementProgress($userId, 'Commenter');
+                }
                 echo json_encode(['success' => true, 'message' => 'Comment added successfully!']);
             } else {
                 echo json_encode(['success' => false, 'error' => 'Failed to add comment']);
@@ -55,9 +64,13 @@ try {
             }
             
             // Add reply
-            $replyId = addCommentReply($commentId, $pasteId, $content, null);
+            $userId = $_SESSION['user_id'] ?? null;
+            $replyId = addCommentReply($commentId, $pasteId, $content, $userId);
             
             if ($replyId) {
+                if ($userId) {
+                    updateAchievementProgress($userId, 'Commenter');
+                }
                 echo json_encode(['success' => true, 'message' => 'Reply added successfully!']);
             } else {
                 echo json_encode(['success' => false, 'error' => 'Failed to add reply']);
@@ -70,5 +83,4 @@ try {
 } catch (Exception $e) {
     error_log("Helper API Error: " . $e->getMessage());
     echo json_encode(['success' => false, 'error' => 'Server error: ' . $e->getMessage()]);
-}
-?>
+}?>

--- a/pages/view-comments.php
+++ b/pages/view-comments.php
@@ -37,7 +37,7 @@
                                             <textarea id="comment-content" class="form-control" name="content" rows="4" placeholder="Write your comment..." required></textarea>
                                         </div>
                                         <button type="submit" class="btn btn-primary" id="comment-submit-btn">
-                                            <i class="fas fa-comment me-1"></i>Post Comment as Anonymous
+                                            <i class="fas fa-comment me-1"></i>Post Comment as <?php echo htmlspecialchars($userData['username'] ?? 'Anonymous'); ?>
                                         </button>
                                     </form>
                                 </div>

--- a/pages/view.php
+++ b/pages/view.php
@@ -65,8 +65,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($action === 'add_comment') {
         $content = trim($_POST['content'] ?? '');
         if (!empty($content)) {
-            $result = addComment($pasteId, $content, null); // null for anonymous
+            $userId = $_SESSION['user_id'] ?? null;
+            $result = addComment($pasteId, $content, $userId);
             if ($result) {
+                if ($userId) {
+                    updateAchievementProgress($userId, 'Commenter');
+                }
                 $success = 'Comment added successfully!';
             } else {
                 $error = 'Failed to add comment.';
@@ -1077,7 +1081,7 @@ if ($paste['line_count'] > $maxLines): ?>
                                             <textarea id="comment-content" class="form-control" name="content" rows="4" placeholder="Write your comment..." required></textarea>
                                         </div>
                                         <button type="submit" class="btn btn-primary" id="comment-submit-btn">
-                                            <i class="fas fa-comment me-1"></i>Post Comment as Anonymous
+                                            <i class="fas fa-comment me-1"></i>Post Comment as <?php echo htmlspecialchars($userData['username'] ?? 'Anonymous'); ?>
                                         </button>
                                     </form>
                                 </div>


### PR DESCRIPTION
## Summary
- make comment APIs session aware
- attribute comments to the logged in user instead of Anonymous
- update comment forms to display the username when logged in
- track progress toward comment achievements

## Testing
- `php -l pages/view.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d660c1f808321960d6d473bf20524