### PR TITLE
Add AJAX comment deletion

### DIFF
--- a/api/delete_comment.php
+++ b/api/delete_comment.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Delete Comment API
+ * Allows users to delete their own comments
+ */
+
+header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/db.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+$commentId = $_POST['comment_id'] ?? '';
+$userId    = $_SESSION['user_id'] ?? null;
+
+if (empty($commentId) || !$userId) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit;
+}
+
+try {
+    $result = deleteComment($commentId, $userId);
+    if ($result) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Unable to delete comment']);
+    }
+} catch (Exception $e) {
+    error_log('Delete comment API error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'error' => 'Server error']);
+}

--- a/api/getcomments.php
+++ b/api/getcomments.php
@@ -5,6 +5,11 @@
  */
 
 require_once __DIR__ . '/../includes/db.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$currentUserId = $_SESSION['user_id'] ?? null;
 
 $pasteId = $_GET['paste_id'] ?? '';
 
@@ -54,8 +59,12 @@ try {
                             <div class="comment-actions">
                                 <button class="btn btn-link btn-sm text-muted p-0 me-3" onclick="toggleReplyForm(' . $comment['id'] . ')">
                                     <i class="fas fa-reply me-1"></i>Reply
-                                </button>
-                            </div>
+                                </button>';
+            if ($currentUserId && $comment['user_id'] == $currentUserId) {
+                echo '<button class="btn btn-link btn-sm text-danger p-0 delete-comment-btn" onclick="deleteComment(' . $comment['id'] . ')" title="Delete comment">'
+                     . '<i class="fas fa-trash-alt"></i></button>';
+            }
+            echo '</div>';
                             
                             <div id="reply-form-' . $comment['id'] . '" class="reply-form mt-3" style="display: none;">
                                 <div class="mb-2">
@@ -125,5 +134,4 @@ try {
     
 } catch (Exception $e) {
     error_log("Get comments error: " . $e->getMessage());
-    echo '<div class="alert alert-danger">Error loading comments: ' . htmlspecialchars($e->getMessage()) . '</div>';
-}?>
+    echo '<div class="alert alert-danger">Error loading comments: ' . htmlspecialchars($e->getMessage()) . '</div>';}?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -448,6 +448,31 @@ function addCommentReply($commentId, $pasteId, $content, $userId = null) {
     }
 }
 
+/**
+ * Delete a comment if it belongs to the given user
+ */
+function deleteComment($commentId, $userId) {
+    global $pdo;
+
+    try {
+        // Verify ownership
+        $stmt = $pdo->prepare("SELECT user_id FROM comments WHERE id = ? AND is_deleted = 0");
+        $stmt->execute([$commentId]);
+        $comment = $stmt->fetch();
+
+        if (!$comment || $comment['user_id'] != $userId) {
+            return false;
+        }
+
+        // Soft delete the comment
+        $stmt = $pdo->prepare("UPDATE comments SET is_deleted = 1 WHERE id = ?");
+        return $stmt->execute([$commentId]);
+    } catch (PDOException $e) {
+        error_log("Delete comment failed: " . $e->getMessage());
+        return false;
+    }
+}
+
 // Discussion Thread Functions
 function getDiscussionThreads($pasteId) {
     $db = getDatabase();

--- a/pages/view.php
+++ b/pages/view.php
@@ -1828,6 +1828,27 @@ if ($paste['line_count'] > $maxLines): ?>
         });
     }
 
+    // Delete a comment via AJAX
+    function deleteComment(commentId) {
+        if (!confirm('Are you sure you want to delete this comment?')) {
+            return;
+        }
+
+        $.post('/api/delete_comment.php', { comment_id: commentId })
+            .done(function(response) {
+                if (response.success) {
+                    // Remove comment element from DOM
+                    document.querySelector('[data-comment-id="' + commentId + '"]').remove();
+                    showNotification('Comment deleted', 'success');
+                } else {
+                    showNotification(response.error || 'Failed to delete comment', 'error');
+                }
+            })
+            .fail(function() {
+                showNotification('Failed to delete comment', 'error');
+            });
+    }
+
     // Show notification
     function showNotification(message, type = 'info') {
         // Remove existing notifications


### PR DESCRIPTION
## Summary
- enable session support in comment fetch endpoint
- show delete icon on comments that belong to the logged-in user
- add server API to delete comments
- expose `deleteComment` helper in database layer
- implement client-side `deleteComment` JS helper

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e6001008321a21bf965bfb32813