### PR TITLE
Enable user-managed discussion editing

### DIFF
--- a/api/discussions.php
+++ b/api/discussions.php
@@ -1,0 +1,67 @@
+<?php
+header('Content-Type: application/json');
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+require_once __DIR__ . '/../includes/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+$userId = $_SESSION['user_id'] ?? null;
+
+try {
+    switch ($action) {
+        case 'edit_thread':
+            if (!$userId) {
+                echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+                exit;
+            }
+            $threadId = $_POST['thread_id'] ?? '';
+            $title = trim($_POST['title'] ?? '');
+            $category = trim($_POST['category'] ?? '');
+            $content = trim($_POST['content'] ?? '');
+            if (!$threadId || !$title || !$category || !$content) {
+                echo json_encode(['success' => false, 'error' => 'Missing data']);
+                exit;
+            }
+            $result = updateDiscussionThread($threadId, $userId, $title, $category, $content);
+            echo json_encode(['success' => $result]);
+            break;
+        case 'edit_post':
+            if (!$userId) {
+                echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+                exit;
+            }
+            $postId = $_POST['post_id'] ?? '';
+            $content = trim($_POST['content'] ?? '');
+            if (!$postId || $content === '') {
+                echo json_encode(['success' => false, 'error' => 'Missing data']);
+                exit;
+            }
+            $result = updateDiscussionPost($postId, $userId, $content);
+            echo json_encode(['success' => $result]);
+            break;
+        case 'delete_post':
+            if (!$userId) {
+                echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+                exit;
+            }
+            $postId = $_POST['post_id'] ?? '';
+            if (!$postId) {
+                echo json_encode(['success' => false, 'error' => 'Missing post id']);
+                exit;
+            }
+            $result = deleteDiscussionPost($postId, $userId);
+            echo json_encode(['success' => $result]);
+            break;
+        default:
+            echo json_encode(['success' => false, 'error' => 'Invalid action']);
+    }
+} catch (Exception $e) {
+    error_log('Discussion API error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'error' => 'Server error']);
+}

--- a/pages/view-header.php
+++ b/pages/view-header.php
@@ -44,11 +44,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $title = trim($_POST['title'] ?? '');
         $category = trim($_POST['category'] ?? '');
         $content = trim($_POST['content'] ?? '');
-        $username = trim($_POST['username'] ?? 'Anonymous');
+        $userId = $_SESSION['user_id'] ?? null;
+        if ($userId) {
+            $stmt = $pdo->prepare("SELECT username FROM users WHERE id = ?");
+            $stmt->execute([$userId]);
+            $username = $stmt->fetchColumn();
+        } else {
+            $username = trim($_POST['username'] ?? 'Anonymous');
+        }
         
         if (!empty($title) && !empty($category) && !empty($content)) {
             try {
-                $threadId = createDiscussionThread($pasteId, $title, $category, $content, $username);
+                $threadId = createDiscussionThread($pasteId, $title, $category, $content, $username, $userId);
                 if ($threadId) {
                     // Redirect to discussions tab to show the new thread
                     header("Location: " . $_SERVER['PHP_SELF'] . "?id=" . $pasteId . "#discussions");
@@ -65,11 +72,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($action === 'add_discussion_post') {
         $threadId = $_POST['thread_id'] ?? '';
         $content = trim($_POST['content'] ?? '');
-        $username = trim($_POST['username'] ?? 'Anonymous');
+        $userId = $_SESSION['user_id'] ?? null;
+        if ($userId) {
+            $stmt = $pdo->prepare("SELECT username FROM users WHERE id = ?");
+            $stmt->execute([$userId]);
+            $username = $stmt->fetchColumn();
+        } else {
+            $username = trim($_POST['username'] ?? 'Anonymous');
+        }
         
         if (!empty($content) && !empty($threadId)) {
             try {
-                $postId = addDiscussionPost($threadId, $content, $username);
+                $postId = addDiscussionPost($threadId, $content, $username, $userId);
                 if ($postId) {
                     // Redirect back to the thread view
                     header("Location: " . $_SERVER['PHP_SELF'] . "?id=" . $pasteId . "&thread=" . $threadId . "#discussions");

--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -143,7 +143,7 @@
                                     
                                     <div class="thread-posts">
                                         <?php foreach ($threadPosts as $index => $post): ?>
-                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>">
+                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>" data-post-id="<?= $post['id'] ?>">
                                             <div class="card-body">
                                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                                     <div class="d-flex align-items-center gap-2">
@@ -157,8 +157,14 @@
                                                         </div>
                                                     </div>
                                                     <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
+                                                    <?php if (isset($_SESSION['user_id']) && $post['user_id'] == $_SESSION['user_id']): ?>
+                                                        <div class="ms-2">
+                                                            <button type="button" class="btn btn-sm btn-link edit-post" data-post-id="<?= $post['id'] ?>"><i class="fas fa-edit"></i></button>
+                                                            <button type="button" class="btn btn-sm btn-link text-danger delete-post" data-post-id="<?= $post['id'] ?>"><i class="fas fa-trash"></i></button>
+                                                        </div>
+                                                    <?php endif; ?>
                                                 </div>
-                                                <div class="mt-2">
+                                                <div class="mt-2" id="post-content-<?= $post['id'] ?>">
                                                     <?= nl2br(htmlspecialchars($post['content'])) ?>
                                                 </div>
                                             </div>
@@ -178,8 +184,8 @@
                                                     
                                                     <div class="mb-3">
                                                         <label for="reply-username" class="form-label">Your Name</label>
-                                                        <input type="text" class="form-control" name="username" id="reply-username" 
-                                                               value="Anonymous" required>
+                                                        <input type="text" class="form-control" name="username" id="reply-username"
+                                                               value="<?= htmlspecialchars($userData['username'] ?? 'Anonymous') ?>" <?= isset($userData['username']) ? 'readonly' : '' ?> required>
                                                     </div>
                                                     
                                                     <div class="mb-3">
@@ -192,6 +198,41 @@
                                                         <i class="fas fa-reply me-1"></i>Post Reply
                                                     </button>
                                                 </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!-- Edit Thread Modal -->
+                                    <div class="modal fade" id="editThreadModal" tabindex="-1" aria-hidden="true">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <h5 class="modal-title">Edit Thread</h5>
+                                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <div class="mb-3">
+                                                        <label for="edit-thread-title" class="form-label">Title</label>
+                                                        <input type="text" class="form-control" id="edit-thread-title">
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label for="edit-thread-category" class="form-label">Category</label>
+                                                        <select id="edit-thread-category" class="form-select">
+                                                            <option value="Q&A">Q&A</option>
+                                                            <option value="Tip">Tip</option>
+                                                            <option value="Idea">Idea</option>
+                                                            <option value="Bug">Bug</option>
+                                                            <option value="General">General</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label for="edit-thread-content" class="form-label">Content</label>
+                                                        <textarea id="edit-thread-content" class="form-control" rows="4"></textarea>
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                                    <button type="button" class="btn btn-primary" id="save-thread-edit">Save</button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- store user ID when creating threads and posts
- add update and delete helpers for discussion threads/posts
- allow logged in users to edit or delete their discussion posts via new API
- include edit thread modal and controls when owning the thread
- show logged-in username when posting replies

## Testing
- `php -l api/discussions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eb64031c483219ddfbab20b4c4b8c