### PR TITLE
Fix Start Discussion modal

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -655,6 +655,17 @@ function showCopySuccess(button) {
     }, 2000);
 }
 
+// Global function to open the "Create Thread" modal if not already defined
+if (typeof showCreateThreadForm === 'undefined') {
+    function showCreateThreadForm() {
+        const modalEl = document.getElementById('create-thread-modal');
+        if (modalEl) {
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+        }
+    }
+}
+
 // Export for potential use in other scripts
 window.PasteForge = {
     ThemeManager,

--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -358,3 +358,46 @@
         </div>
     </div>
 
+    <!-- Create Thread Modal -->
+    <div class="modal fade" id="create-thread-modal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form method="POST" id="create-thread-modal-form">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Start New Discussion</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <input type="hidden" name="action" value="create_discussion_thread">
+                        <input type="hidden" name="paste_id" value="<?php echo $paste['id']; ?>">
+                        <div class="mb-3">
+                            <label for="thread-title-modal" class="form-label">Discussion Title</label>
+                            <input type="text" class="form-control" id="thread-title-modal" name="title" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="thread-category-modal" class="form-label">Category</label>
+                            <select class="form-select" id="thread-category-modal" name="category" required>
+                                <option value="">Choose category...</option>
+                                <option value="Q&A">Q&A - Questions & Answers</option>
+                                <option value="Tip">Tip - Helpful Tips</option>
+                                <option value="Idea">Idea - Improvements & Ideas</option>
+                                <option value="Bug">Bug - Bug Reports</option>
+                                <option value="General">General - General Discussion</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="thread-content-modal" class="form-label">Initial Post</label>
+                            <textarea class="form-control" id="thread-content-modal" name="content" rows="5" required></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-paper-plane me-1"></i>Create Discussion
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+

--- a/pages/view.php
+++ b/pages/view.php
@@ -2259,4 +2259,47 @@ if ($paste['line_count'] > $maxLines): ?>
     <?php endif; ?>
 </main>
 
+<!-- Create Thread Modal -->
+<div class="modal fade" id="create-thread-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="POST" id="create-thread-modal-form">
+                <div class="modal-header">
+                    <h5 class="modal-title">Start New Discussion</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="action" value="create_discussion_thread">
+                    <input type="hidden" name="paste_id" value="<?php echo $pasteId; ?>">
+                    <div class="mb-3">
+                        <label for="thread-title-modal" class="form-label">Discussion Title</label>
+                        <input type="text" class="form-control" id="thread-title-modal" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="thread-category-modal" class="form-label">Category</label>
+                        <select class="form-select" id="thread-category-modal" name="category" required>
+                            <option value="">Choose category...</option>
+                            <option value="Q&A">Q&A - Questions & Answers</option>
+                            <option value="Tip">Tip - Helpful Tips</option>
+                            <option value="Idea">Idea - Improvements & Ideas</option>
+                            <option value="Bug">Bug - Bug Reports</option>
+                            <option value="General">General - General Discussion</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="thread-content-modal" class="form-label">Initial Post</label>
+                        <textarea class="form-control" id="thread-content-modal" name="content" rows="5" required></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-paper-plane me-1"></i>Create Discussion
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <?php include '../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add global JS function to open `create-thread-modal`
- include new discussion modal on paste view pages

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec0146b0c832183654f87003d67cd