### PR TITLE
Fix discussion loggedin username

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -500,25 +500,25 @@ function getDiscussionPosts($threadId) {
     return $stmt->fetchAll();
 }
 
-function createDiscussionThread($pasteId, $title, $category, $content, $username = 'Anonymous') {
+function createDiscussionThread($pasteId, $title, $category, $content, $userId = null, $username = 'Anonymous') {
     $db = getDatabase();
     $db->beginTransaction();
     
     try {
         // Create thread
-        $stmt = $db->prepare("
-            INSERT INTO paste_discussion_threads (paste_id, username, title, category)
-            VALUES (?, ?, ?, ?)
-        ");
-        $stmt->execute([$pasteId, $username, $title, $category]);
+        $stmt = $db->prepare(
+            "INSERT INTO paste_discussion_threads (paste_id, user_id, username, title, category)
+            VALUES (?, ?, ?, ?, ?)"
+        );
+        $stmt->execute([$pasteId, $userId, $username, $title, $category]);
         $threadId = $db->lastInsertId();
         
         // Create initial post
-        $stmt = $db->prepare("
-            INSERT INTO paste_discussion_posts (thread_id, username, content)
-            VALUES (?, ?, ?)
-        ");
-        $stmt->execute([$threadId, $username, $content]);
+        $stmt = $db->prepare(
+            "INSERT INTO paste_discussion_posts (thread_id, user_id, username, content)
+            VALUES (?, ?, ?, ?)"
+        );
+        $stmt->execute([$threadId, $userId, $username, $content]);
         
         $db->commit();
         return $threadId;
@@ -528,13 +528,13 @@ function createDiscussionThread($pasteId, $title, $category, $content, $username
     }
 }
 
-function addDiscussionPost($threadId, $content, $username = 'Anonymous') {
+function addDiscussionPost($threadId, $content, $userId = null, $username = 'Anonymous') {
     $db = getDatabase();
-    $stmt = $db->prepare("
-        INSERT INTO paste_discussion_posts (thread_id, username, content)
-        VALUES (?, ?, ?)
-    ");
-    $stmt->execute([$threadId, $username, $content]);
+    $stmt = $db->prepare(
+        "INSERT INTO paste_discussion_posts (thread_id, user_id, username, content)
+        VALUES (?, ?, ?, ?)"
+    );
+    $stmt->execute([$threadId, $userId, $username, $content]);
     return $db->lastInsertId();
 }
 

--- a/login.php
+++ b/login.php
@@ -19,6 +19,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $user = $stmt->fetch();
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user_id'] = $user['id'];
+            // Store username in session for convenience
+            $_SESSION['username'] = $user['username'];
             header('Location: index.php');
             exit();
         } else {

--- a/pages/view-header.php
+++ b/pages/view-header.php
@@ -44,11 +44,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $title = trim($_POST['title'] ?? '');
         $category = trim($_POST['category'] ?? '');
         $content = trim($_POST['content'] ?? '');
+        $userId = $_SESSION['user_id'] ?? null;
         $username = trim($_POST['username'] ?? 'Anonymous');
+        if ($userId) {
+            $username = $_SESSION['username'] ?? null;
+            if (!$username) {
+                $stmt = $pdo->prepare('SELECT username FROM users WHERE id = ?');
+                $stmt->execute([$userId]);
+                $username = $stmt->fetchColumn() ?: 'Anonymous';
+                $_SESSION['username'] = $username;
+            }
+        }
         
         if (!empty($title) && !empty($category) && !empty($content)) {
             try {
-                $threadId = createDiscussionThread($pasteId, $title, $category, $content, $username);
+                $threadId = createDiscussionThread($pasteId, $title, $category, $content, $userId, $username);
                 if ($threadId) {
                     // Redirect to discussions tab to show the new thread
                     header("Location: " . $_SERVER['PHP_SELF'] . "?id=" . $pasteId . "#discussions");
@@ -65,11 +75,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($action === 'add_discussion_post') {
         $threadId = $_POST['thread_id'] ?? '';
         $content = trim($_POST['content'] ?? '');
+        $userId = $_SESSION['user_id'] ?? null;
         $username = trim($_POST['username'] ?? 'Anonymous');
+        if ($userId) {
+            $username = $_SESSION['username'] ?? null;
+            if (!$username) {
+                $stmt = $pdo->prepare('SELECT username FROM users WHERE id = ?');
+                $stmt->execute([$userId]);
+                $username = $stmt->fetchColumn() ?: 'Anonymous';
+                $_SESSION['username'] = $username;
+            }
+        }
         
         if (!empty($content) && !empty($threadId)) {
             try {
-                $postId = addDiscussionPost($threadId, $content, $username);
+                $postId = addDiscussionPost($threadId, $content, $userId, $username);
                 if ($postId) {
                     // Redirect back to the thread view
                     header("Location: " . $_SERVER['PHP_SELF'] . "?id=" . $pasteId . "&thread=" . $threadId . "#discussions");

--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -176,11 +176,16 @@
                                                     <input type="hidden" name="action" value="add_discussion_post">
                                                     <input type="hidden" name="thread_id" value="<?= $thread['id'] ?>">
                                                     
+                                                    <?php if (!empty($userData['username'])): ?>
+                                                        <input type="hidden" name="username" value="<?= htmlspecialchars($userData['username']) ?>">
+                                                        <p class="mb-3">Replying as <?= htmlspecialchars($userData['username']) ?></p>
+                                                    <?php else: ?>
                                                     <div class="mb-3">
                                                         <label for="reply-username" class="form-label">Your Name</label>
-                                                        <input type="text" class="form-control" name="username" id="reply-username" 
+                                                        <input type="text" class="form-control" name="username" id="reply-username"
                                                                value="Anonymous" required>
                                                     </div>
+                                                    <?php endif; ?>
                                                     
                                                     <div class="mb-3">
                                                         <label for="reply-content" class="form-label">Your Reply</label>


### PR DESCRIPTION
This pull request introduces changes to support user authentication and improve user identification in discussion threads and posts. The updates ensure that logged-in users are associated with their `user_id` and username while allowing anonymous contributions when no user is logged in. Below is a summary of the most important changes grouped by theme.

### Database Updates for User Identification:
* Updated `createDiscussionThread` and `addDiscussionPost` functions in `includes/db.php` to include `user_id` as an optional parameter, allowing threads and posts to be associated with authenticated users. [[1]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L503-R521) [[2]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L531-R537)

### Session Management:
* Modified `login.php` to store the logged-in user's username in the session for convenience.

### User Identification in Threads and Posts:
* Updated `pages/view-header.php` and `pages/view.php` to retrieve the username from the session for logged-in users, falling back to database queries if necessary. Anonymous contributions remain supported. [[1]](diffhunk://#diff-db83b698bad12343b671a8d173a2084442ccbbb19779af0ee343f712151e37e4R47-R61) [[2]](diffhunk://#diff-db83b698bad12343b671a8d173a2084442ccbbb19779af0ee343f712151e37e4R78-R92) [[3]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R85-R99) [[4]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R116-R130)

### UI Enhancements for Replies:
* Adjusted `pages/view-tabs.php` and `pages/view.php` to display the logged-in user's username when replying to threads, while maintaining an input field for anonymous users. [[1]](diffhunk://#diff-93352a0adc526dc2a277f70763cb8e409dff1e52f942710d5bc11e4427ba045eR179-R188) [[2]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R1181-R1190)This pull request introduces changes to support user authentication and enhance the handling of user-specific data in discussion threads and posts. The updates ensure that authenticated users can participate in discussions with their usernames automatically populated, while unauthenticated users can still post as "Anonymous." Key updates include modifications to the database schema, session handling, and user interface elements.

### User Authentication and Session Handling

* [`login.php`](diffhunk://#diff-b5866acb4c2b0d900c2623c453f9cf056193de7d29b280e8a9ceb7ef94bd28adR22-R23): Added functionality to store the authenticated user's username in the session for convenience. (`[login.phpR22-R23](diffhunk://#diff-b5866acb4c2b0d900c2623c453f9cf056193de7d29b280e8a9ceb7ef94bd28adR22-R23)`)

### Database and Backend Updates

* [`includes/db.php`](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L503-R521): Updated `createDiscussionThread` and `addDiscussionPost` functions to accept `userId` as an optional parameter and include it in database inserts for tracking posts by authenticated users. (`[[1]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L503-R521)`, `[[2]](diffhunk://#diff-8e563e348f0815e931a2e282aa993008f6eec0fc19b679d907c424deca3e16a9L531-R537)`)

### Frontend Enhancements for Discussions

* `pages/view-header.php` and `pages/view.php`: Enhanced logic to automatically retrieve and use the username from the session for authenticated users when creating threads or posts. Added fallback to fetch the username from the database if missing in the session. (`[[1]](diffhunk://#diff-db83b698bad12343b671a8d173a2084442ccbbb19779af0ee343f712151e37e4R47-R61)`, `[[2]](diffhunk://#diff-db83b698bad12343b671a8d173a2084442ccbbb19779af0ee343f712151e37e4R78-R92)`, `[[3]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R85-R99)`, `[[4]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R116-R130)`)
* `pages/view-tabs.php` and `pages/view.php`: Updated the discussion reply form to display the authenticated user's username when available, or provide an input field for unauthenticated users to specify their name. (`[[1]](diffhunk://#diff-93352a0adc526dc2a277f70763cb8e409dff1e52f942710d5bc11e4427ba045eR179-R188)`, `[[2]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R1181-R1190)`)