### PR TITLE
Enable AJAX discussion deletion

### DIFF
--- a/api/delete_discussion_post.php
+++ b/api/delete_discussion_post.php
@@ -1,0 +1,31 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/db.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+$postId = $_POST['post_id'] ?? '';
+$userId = $_SESSION['user_id'] ?? null;
+
+if (empty($postId) || !$userId) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit;
+}
+
+try {
+    $result = deleteDiscussionPost($postId, $userId);
+    if ($result) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Unable to delete post']);
+    }
+} catch (Exception $e) {
+    error_log('Delete discussion post API error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'error' => 'Server error']);
+}

--- a/api/delete_discussion_thread.php
+++ b/api/delete_discussion_thread.php
@@ -1,0 +1,31 @@
+<?php
+header('Content-Type: application/json');
+require_once __DIR__ . '/../includes/db.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+$threadId = $_POST['thread_id'] ?? '';
+$userId   = $_SESSION['user_id'] ?? null;
+
+if (empty($threadId) || !$userId) {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit;
+}
+
+try {
+    $result = deleteDiscussionThread($threadId, $userId);
+    if ($result) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Unable to delete thread']);
+    }
+} catch (Exception $e) {
+    error_log('Delete discussion thread API error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'error' => 'Server error']);
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -547,6 +547,46 @@ function getDiscussionThread($threadId) {
     return $stmt->fetch();
 }
 
+function deleteDiscussionThread($threadId, $userId) {
+    global $pdo;
+
+    try {
+        $stmt = $pdo->prepare("SELECT user_id FROM paste_discussion_threads WHERE id = ?");
+        $stmt->execute([$threadId]);
+        $thread = $stmt->fetch();
+
+        if (!$thread || $thread['user_id'] != $userId) {
+            return false;
+        }
+
+        $stmt = $pdo->prepare("DELETE FROM paste_discussion_threads WHERE id = ?");
+        return $stmt->execute([$threadId]);
+    } catch (PDOException $e) {
+        error_log('Delete discussion thread failed: ' . $e->getMessage());
+        return false;
+    }
+}
+
+function deleteDiscussionPost($postId, $userId) {
+    global $pdo;
+
+    try {
+        $stmt = $pdo->prepare("SELECT user_id FROM paste_discussion_posts WHERE id = ? AND is_deleted = 0");
+        $stmt->execute([$postId]);
+        $post = $stmt->fetch();
+
+        if (!$post || $post['user_id'] != $userId) {
+            return false;
+        }
+
+        $stmt = $pdo->prepare("UPDATE paste_discussion_posts SET is_deleted = 1 WHERE id = ?");
+        return $stmt->execute([$postId]);
+    } catch (PDOException $e) {
+        error_log('Delete discussion post failed: ' . $e->getMessage());
+        return false;
+    }
+}
+
 /**
  * Log password access attempts for a paste
  */

--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -116,6 +116,11 @@
                                         <button class="btn btn-outline-secondary btn-sm" onclick="backToDiscussions()">
                                             <i class="fas fa-arrow-left me-1"></i>Back to Discussions
                                         </button>
+                                        <?php if (!empty($userData['id']) && $thread['user_id'] == $userData['id']): ?>
+                                        <button class="btn btn-link btn-sm text-danger" onclick="deleteDiscussionThread(<?= $thread['id'] ?>)">
+                                            <i class="fas fa-trash-alt"></i>
+                                        </button>
+                                        <?php endif; ?>
                                     </div>
                                     
                                     <div class="mb-4">
@@ -143,7 +148,7 @@
                                     
                                     <div class="thread-posts">
                                         <?php foreach ($threadPosts as $index => $post): ?>
-                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>">
+                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>" id="post-<?= $post['id'] ?>">
                                             <div class="card-body">
                                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                                     <div class="d-flex align-items-center gap-2">
@@ -156,7 +161,14 @@
                                                             <?php endif; ?>
                                                         </div>
                                                     </div>
-                                                    <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
+                                                    <div class="d-flex align-items-center gap-2">
+                                                        <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
+                                                        <?php if (!empty($userData['id']) && $post['user_id'] == $userData['id']): ?>
+                                                        <button class="btn btn-link btn-sm text-danger p-0" onclick="deleteDiscussionPost(<?= $post['id'] ?>)">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                        </button>
+                                                        <?php endif; ?>
+                                                    </div>
                                                 </div>
                                                 <div class="mt-2">
                                                     <?= nl2br(htmlspecialchars($post['content'])) ?>
@@ -243,8 +255,8 @@
                                         </div>
                                         <?php else: ?>
                                             <?php foreach ($threads as $thread): ?>
-                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow" onclick="viewThread(<?php echo $thread['id']; ?>)">
-                                                <div class="d-flex align-items-start">
+                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow" id="thread-<?= $thread['id']; ?>" onclick="viewThread(<?php echo $thread['id']; ?>)">
+                                                <div class="d-flex align-items-start w-100">
                                                     <div class="avatar-container me-3">
                                                         <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMjAiIGN5PSIyMCIgcj0iMjAiIGZpbGw9IiM5Y2E2ZjciLz4KPHN2ZyB4PSIxMCIgeT0iMTAiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIiBmaWxsPSIjZmZmIj4KPHBhdGggZD0iTTEwIDEwYy0xIDAtMS41LS41LTEuNS0xLjVzLjUtMS41IDEuNS0xLjUgMS41LjUgMS41IDEuNS0uNSAxLjUtMS41IDEuNXptNSAwYy40NSAwIDEuMi0uNSAxLjItMS41cy0uNS0xLjUtMS4yLTEuNS0xLjIuNS0xLjIgMS41LjUgMS41IDEuMiAxLjV6Ii8+Cjwvc3ZnPgo8L3N2Zz4K" 
                                                              alt="Avatar" class="rounded-circle" width="40" height="40">
@@ -260,6 +272,11 @@
                                                             <span><i class="fas fa-reply me-1"></i><?php echo $thread['reply_count']; ?> replies</span>
                                                         </div>
                                                     </div>
+                                                    <?php if (!empty($userData['id']) && $thread['user_id'] == $userData['id']): ?>
+                                                    <button class="btn btn-link btn-sm text-danger ms-auto" onclick="deleteDiscussionThread(<?= $thread['id']; ?>); event.stopPropagation();">
+                                                        <i class="fas fa-trash-alt"></i>
+                                                    </button>
+                                                    <?php endif; ?>
                                                 </div>
                                             </div>
                                             <?php endforeach; ?>

--- a/pages/view.php
+++ b/pages/view.php
@@ -1874,6 +1874,45 @@ if ($paste['line_count'] > $maxLines): ?>
             });
     }
 
+    function deleteDiscussionPost(postId) {
+        if (!confirm('Are you sure you want to delete this post?')) {
+            return;
+        }
+
+        $.post('/api/delete_discussion_post.php', { post_id: postId })
+            .done(function(response) {
+                if (response.success) {
+                    document.getElementById('post-' + postId).remove();
+                    showNotification('Post deleted', 'success');
+                } else {
+                    showNotification(response.error || 'Failed to delete post', 'error');
+                }
+            })
+            .fail(function() {
+                showNotification('Failed to delete post', 'error');
+            });
+    }
+
+    function deleteDiscussionThread(threadId) {
+        if (!confirm('Are you sure you want to delete this thread?')) {
+            return;
+        }
+
+        $.post('/api/delete_discussion_thread.php', { thread_id: threadId })
+            .done(function(response) {
+                if (response.success) {
+                    var elem = document.getElementById('thread-' + threadId);
+                    if (elem) { elem.remove(); }
+                    showNotification('Thread deleted', 'success');
+                } else {
+                    showNotification(response.error || 'Failed to delete thread', 'error');
+                }
+            })
+            .fail(function() {
+                showNotification('Failed to delete thread', 'error');
+            });
+    }
+
     // Show notification
     function showNotification(message, type = 'info') {
         // Remove existing notifications


### PR DESCRIPTION
## Summary
- allow authors to delete their own threads and posts
- expose API endpoints for deleting discussion posts and threads
- show delete icons for owned discussion content
- update view JS to remove posts/threads without page reload

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686eca3c2ab88321ad6cfb79ec79ee08