### PR TITLE
Fix thread/post delete button ownership check

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -7,7 +7,7 @@ if (!isset($pdo)) {
 }
 $userData = null;
 if (isset($_SESSION['user_id'])) {
-    $stmt = $pdo->prepare("SELECT username, profile_image FROM users WHERE id = ?");
+    $stmt = $pdo->prepare("SELECT id, username, profile_image FROM users WHERE id = ?");
     $stmt->execute([$_SESSION['user_id']]);
     $userData = $stmt->fetch();
     if ($userData) {

--- a/pages/view-tabs.php
+++ b/pages/view-tabs.php
@@ -116,7 +116,12 @@
                                         <button class="btn btn-outline-secondary btn-sm" onclick="backToDiscussions()">
                                             <i class="fas fa-arrow-left me-1"></i>Back to Discussions
                                         </button>
-                                        <?php if (!empty($userData['id']) && $thread['user_id'] == $userData['id']): ?>
+                                        <?php
+                                        $canDeleteThread = !empty($userData['id']) && (
+                                            (!empty($thread['user_id']) && $thread['user_id'] == $userData['id']) ||
+                                            (empty($thread['user_id']) && $thread['username'] === ($userData['username'] ?? ''))
+                                        );
+                                        if ($canDeleteThread): ?>
                                         <button class="btn btn-link btn-sm text-danger" onclick="deleteDiscussionThread(<?= $thread['id'] ?>)">
                                             <i class="fas fa-trash-alt"></i>
                                         </button>
@@ -163,7 +168,12 @@
                                                     </div>
                                                     <div class="d-flex align-items-center gap-2">
                                                         <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
-                                                        <?php if (!empty($userData['id']) && $post['user_id'] == $userData['id']): ?>
+                                                        <?php
+                                                        $canDeletePost = !empty($userData['id']) && (
+                                                            (!empty($post['user_id']) && $post['user_id'] == $userData['id']) ||
+                                                            (empty($post['user_id']) && $post['username'] === ($userData['username'] ?? ''))
+                                                        );
+                                                        if ($canDeletePost): ?>
                                                         <button class="btn btn-link btn-sm text-danger p-0" onclick="deleteDiscussionPost(<?= $post['id'] ?>)">
                                                             <i class="fas fa-trash-alt"></i>
                                                         </button>
@@ -255,7 +265,7 @@
                                         </div>
                                         <?php else: ?>
                                             <?php foreach ($threads as $thread): ?>
-                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow" id="thread-<?= $thread['id']; ?>" onclick="viewThread(<?php echo $thread['id']; ?>)">
+                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow position-relative" id="thread-<?= $thread['id']; ?>" onclick="viewThread(<?php echo $thread['id']; ?>)">
                                                 <div class="d-flex align-items-start w-100">
                                                     <div class="avatar-container me-3">
                                                         <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMjAiIGN5PSIyMCIgcj0iMjAiIGZpbGw9IiM5Y2E2ZjciLz4KPHN2ZyB4PSIxMCIgeT0iMTAiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIiBmaWxsPSIjZmZmIj4KPHBhdGggZD0iTTEwIDEwYy0xIDAtMS41LS41LTEuNS0xLjVzLjUtMS41IDEuNS0xLjUgMS41LjUgMS41IDEuNS0uNSAxLjUtMS41IDEuNXptNSAwYy40NSAwIDEuMi0uNSAxLjItMS41cy0uNS0xLjUtMS4yLTEuNS0xLjIuNS0xLjIgMS41LjUgMS41IDEuMiAxLjV6Ii8+Cjwvc3ZnPgo8L3N2Zz4K" 
@@ -272,8 +282,13 @@
                                                             <span><i class="fas fa-reply me-1"></i><?php echo $thread['reply_count']; ?> replies</span>
                                                         </div>
                                                     </div>
-                                                    <?php if (!empty($userData['id']) && $thread['user_id'] == $userData['id']): ?>
-                                                    <button class="btn btn-link btn-sm text-danger ms-auto" onclick="deleteDiscussionThread(<?= $thread['id']; ?>); event.stopPropagation();">
+                                                    <?php
+                                                    $canDeleteList = !empty($userData['id']) && (
+                                                        (!empty($thread['user_id']) && $thread['user_id'] == $userData['id']) ||
+                                                        (empty($thread['user_id']) && $thread['username'] === ($userData['username'] ?? ''))
+                                                    );
+                                                    if ($canDeleteList): ?>
+                                                    <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" onclick="deleteDiscussionThread(<?= $thread['id']; ?>); event.stopPropagation();">
                                                         <i class="fas fa-trash-alt"></i>
                                                     </button>
                                                     <?php endif; ?>

--- a/pages/view.php
+++ b/pages/view.php
@@ -1118,6 +1118,16 @@ if ($paste['line_count'] > $maxLines): ?>
                                         <button class="btn btn-outline-secondary btn-sm" onclick="backToDiscussions()">
                                             <i class="fas fa-arrow-left me-1"></i>Back to Discussions
                                         </button>
+                                        <?php
+                                        $canDeleteThread = !empty($userData['id']) && (
+                                            (!empty($thread['user_id']) && $thread['user_id'] == $userData['id']) ||
+                                            (empty($thread['user_id']) && $thread['username'] === ($userData['username'] ?? ''))
+                                        );
+                                        if ($canDeleteThread): ?>
+                                        <button class="btn btn-link btn-sm text-danger" onclick="deleteDiscussionThread(<?= $thread['id'] ?>)">
+                                            <i class="fas fa-trash-alt"></i>
+                                        </button>
+                                        <?php endif; ?>
                                     </div>
                                     
                                     <div class="mb-4">
@@ -1158,7 +1168,19 @@ if ($paste['line_count'] > $maxLines): ?>
                                                             <?php endif; ?>
                                                         </div>
                                                     </div>
-                                                    <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
+                                                    <div class="d-flex align-items-center gap-2">
+                                                        <small class="text-muted"><?= date('M j, Y \a\t g:i A', $post['created_at']) ?></small>
+                                                        <?php
+                                                        $canDeletePost = !empty($userData['id']) && (
+                                                            (!empty($post['user_id']) && $post['user_id'] == $userData['id']) ||
+                                                            (empty($post['user_id']) && $post['username'] === ($userData['username'] ?? ''))
+                                                        );
+                                                        if ($canDeletePost): ?>
+                                                        <button class="btn btn-link btn-sm text-danger p-0" onclick="deleteDiscussionPost(<?= $post['id'] ?>)">
+                                                            <i class="fas fa-trash-alt"></i>
+                                                        </button>
+                                                        <?php endif; ?>
+                                                    </div>
                                                 </div>
                                                 <div class="mt-2">
                                                     <?= nl2br(htmlspecialchars($post['content'])) ?>
@@ -1245,8 +1267,8 @@ if ($paste['line_count'] > $maxLines): ?>
                                         </div>
                                         <?php else: ?>
                                             <?php foreach ($threads as $thread): ?>
-                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow" onclick="viewThread(<?php echo $thread['id']; ?>)">
-                                                <div class="d-flex align-items-start">
+                                            <div class="discussion-thread-item mb-3 p-3 border rounded hover-shadow position-relative" id="thread-<?= $thread['id']; ?>" onclick="viewThread(<?php echo $thread['id']; ?>)">
+                                                <div class="d-flex align-items-start w-100">
                                                     <div class="avatar-container me-3">
                                                         <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMjAiIGN5PSIyMCIgcj0iMjAiIGZpbGw9IiM5Y2E2ZjciLz4KPHN2ZyB4PSIxMCIgeT0iMTAiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDIwIDIwIiBmaWxsPSIjZmZmIj4KPHBhdGggZD0iTTEwIDEwYy0xIDAtMS41LS41LTEuNS0xLjVzLjUtMS41IDEuNS0xLjUgMS41LjUgMS41IDEuNS0uNSAxLjUtMS41IDEuNXptNSAwYy40NSAwIDEuMi0uNSAxLjItMS41cy0uNS0xLjUtMS4yLTEuNS0xLjIuNS0xLjIgMS41LjUgMS41IDEuMiAxLjV6Ii8+Cjwvc3ZnPgo8L3N2Zz4K" 
                                                              alt="Avatar" class="rounded-circle" width="40" height="40">
@@ -1262,7 +1284,18 @@ if ($paste['line_count'] > $maxLines): ?>
                                                             <span><i class="fas fa-reply me-1"></i><?php echo $thread['reply_count']; ?> replies</span>
                                                         </div>
                                                     </div>
+                                                    <?php
+                                                    $canDeleteList = !empty($userData['id']) && (
+                                                        (!empty($thread['user_id']) && $thread['user_id'] == $userData['id']) ||
+                                                        (empty($thread['user_id']) && $thread['username'] === ($userData['username'] ?? ''))
+                                                    );
+                                                    if ($canDeleteList): ?>
+                                                    <button class="btn btn-link btn-sm text-danger position-absolute top-0 end-0" onclick="deleteDiscussionThread(<?= $thread['id']; ?>); event.stopPropagation();">
+                                                        <i class="fas fa-trash-alt"></i>
+                                                    </button>
+                                                    <?php endif; ?>
                                                 </div>
+                                            </div>
                                             </div>
                                             <?php endforeach; ?>
                                         <?php endif; ?>


### PR DESCRIPTION
## Summary
- expose `id` in user session data
- show delete buttons when viewing own discussion thread or post
- ensure delete button is positioned in the thread list

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecee412b08321be5dcdb05d1ac217