### PR TITLE
Fix discussion post deletion

### DIFF
--- a/pages/view.php
+++ b/pages/view.php
@@ -1155,7 +1155,7 @@ if ($paste['line_count'] > $maxLines): ?>
                                     
                                     <div class="thread-posts">
                                         <?php foreach ($threadPosts as $index => $post): ?>
-                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>">
+                                        <div class="card mb-3 <?= $index === 0 ? 'border-primary' : '' ?>" id="post-<?= $post['id'] ?>">
                                             <div class="card-body">
                                                 <div class="d-flex justify-content-between align-items-start mb-2">
                                                     <div class="d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- add post ID attribute so delete_post AJAX can remove post from DOM

## Testing
- `php -l pages/view.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed87561cc832187c1061c53c31f8f