### PR TITLE
Fix dropdown menu stacking context

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1084,7 +1084,7 @@ html {
 }
 
 .dropdown-menu {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
     border-radius: 12px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
@@ -1129,7 +1129,7 @@ html {
     right: 0 !important;
     left: auto !important;
     min-width: 200px;
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
 }
 
@@ -1159,7 +1159,7 @@ html {
 
 /* Special handling for dropdown positioning */
 .paste-header .dropdown {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: relative !important;
 }
 
@@ -1169,7 +1169,7 @@ html {
 }
 
 .paste-header .dropdown-menu.show {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
     will-change: transform !important;
     backface-visibility: hidden !important;
@@ -2141,12 +2141,12 @@ button[disabled] {
 
 .paste-header .dropdown {
     position: relative;
-    z-index: 1050;
+    z-index: 1070;
 }
 
 .paste-header .dropdown-menu {
     position: absolute;
-    z-index: 1050;
+    z-index: 1070;
     will-change: transform;
 }
 


### PR DESCRIPTION
## Summary
- ensure dropdown menus render above card containers
- boost paste-header dropdown stacking values

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef912f40083218c74b6692b35a5bd