### PR TITLE
Fix dropdown zindex

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1084,7 +1084,7 @@ html {
 }
 
 .dropdown-menu {
-    z-index: 9999 !important;
+    z-index: 1050 !important;
     position: absolute !important;
     border-radius: 12px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
@@ -1129,7 +1129,7 @@ html {
     right: 0 !important;
     left: auto !important;
     min-width: 200px;
-    z-index: 10000 !important;
+    z-index: 1050 !important;
     position: absolute !important;
 }
 
@@ -1159,7 +1159,7 @@ html {
 
 /* Special handling for dropdown positioning */
 .paste-header .dropdown {
-    z-index: 10001 !important;
+    z-index: 1050 !important;
     position: relative !important;
 }
 
@@ -1169,7 +1169,7 @@ html {
 }
 
 .paste-header .dropdown-menu.show {
-    z-index: 2147483647 !important; /* Maximum safe z-index */
+    z-index: 1050 !important;
     position: absolute !important;
     will-change: transform !important;
     backface-visibility: hidden !important;
@@ -2141,12 +2141,12 @@ button[disabled] {
 
 .paste-header .dropdown {
     position: relative;
-    z-index: 11;
+    z-index: 1050;
 }
 
 .paste-header .dropdown-menu {
     position: absolute;
-    z-index: 12;
+    z-index: 1050;
     will-change: transform;
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1084,7 +1084,7 @@ html {
 }
 
 .dropdown-menu {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
     border-radius: 12px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
@@ -1129,7 +1129,7 @@ html {
     right: 0 !important;
     left: auto !important;
     min-width: 200px;
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
 }
 
@@ -1159,7 +1159,7 @@ html {
 
 /* Special handling for dropdown positioning */
 .paste-header .dropdown {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: relative !important;
 }
 
@@ -1169,7 +1169,7 @@ html {
 }
 
 .paste-header .dropdown-menu.show {
-    z-index: 1050 !important;
+    z-index: 1070 !important;
     position: absolute !important;
     will-change: transform !important;
     backface-visibility: hidden !important;
@@ -2141,12 +2141,12 @@ button[disabled] {
 
 .paste-header .dropdown {
     position: relative;
-    z-index: 1050;
+    z-index: 1070;
 }
 
 .paste-header .dropdown-menu {
     position: absolute;
-    z-index: 1050;
+    z-index: 1070;
     will-change: transform;
 }
 

--- a/pages/view.php
+++ b/pages/view.php
@@ -667,7 +667,7 @@ include '../includes/header.php';
                             </button>
                             <?php endif; ?>
                             <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" title="More Options">
+                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" data-bs-offset="0,8" data-bs-placement="bottom-end" title="More Options">
                                     <i class="fas fa-ellipsis-h"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end">
@@ -690,7 +690,7 @@ include '../includes/header.php';
                         <!-- Mobile Action Button -->
                         <div class="d-md-none ms-3">
                             <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" title="Actions">
+                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" data-bs-offset="0,8" data-bs-placement="bottom-end" title="Actions">
                                     <i class="fas fa-ellipsis-v"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end">

--- a/pages/view.php
+++ b/pages/view.php
@@ -666,65 +666,15 @@ include '../includes/header.php';
                                 <i class="fas fa-flag me-1"></i>Report
                             </button>
                             <?php endif; ?>
-                            <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" data-bs-offset="0,8" data-bs-placement="bottom-end" title="More Options">
-                                    <i class="fas fa-ellipsis-h"></i>
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-end">
-                                    <li><a class="dropdown-item" href="#" onclick="sharePaste()">
-                                        <i class="fas fa-share me-2"></i>Share Paste
-                                    </a></li>
-                                    <li><hr class="dropdown-divider"></li>
-                                    <li><a class="dropdown-item" href="create.php?clone=<?php echo $pasteId; ?>">
-                                        <i class="fas fa-clone me-2"></i>Clone Paste
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="create.php?fork=<?php echo $pasteId; ?>">
-                                        <i class="fas fa-code-branch me-2"></i>Fork Paste
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="addToFavorites()">
-                                        <i class="far fa-heart me-2"></i>Add to Favorites
-                                    </a></li>
-                                </ul>
-                            </div>
+                            <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="offcanvas" data-bs-target="#actionsOffcanvas" aria-controls="actionsOffcanvas" title="More Options">
+                                <i class="fas fa-ellipsis-h"></i>
+                            </button>
                         </div>
                         <!-- Mobile Action Button -->
                         <div class="d-md-none ms-3">
-                            <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" data-bs-offset="0,8" data-bs-placement="bottom-end" title="Actions">
-                                    <i class="fas fa-ellipsis-v"></i>
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-end">
-                                    <li><a class="dropdown-item" href="#" onclick="viewRaw()">
-                                        <i class="fas fa-file-alt me-2"></i>View Raw
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="downloadPaste()">
-                                        <i class="fas fa-download me-2"></i>Download
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="sharePaste()">
-                                        <i class="fas fa-share me-2"></i>Share Paste
-                                    </a></li>
-                                    <li><hr class="dropdown-divider"></li>
-                                    <?php if ($hasFlagged): ?>
-                                    <li><span class="dropdown-item text-muted disabled">
-                                        <i class="fas fa-flag me-2"></i>You already reported this paste
-                                    </span></li>
-                                    <?php else: ?>
-                                    <li><a class="dropdown-item text-danger" href="#" onclick="reportPaste('<?php echo $pasteId; ?>')">
-                                        <i class="fas fa-flag me-2"></i>Report Paste
-                                    </a></li>
-                                    <?php endif; ?>
-                                    <li><hr class="dropdown-divider"></li>
-                                    <li><a class="dropdown-item" href="create.php?clone=<?php echo $pasteId; ?>">
-                                        <i class="fas fa-clone me-2"></i>Clone Paste
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="create.php?fork=<?php echo $pasteId; ?>">
-                                        <i class="fas fa-code-branch me-2"></i>Fork Paste
-                                    </a></li>
-                                    <li><a class="dropdown-item" href="#" onclick="addToFavorites()">
-                                        <i class="far fa-heart me-2"></i>Add to Favorites
-                                    </a></li>
-                                </ul>
-                            </div>
+                            <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="offcanvas" data-bs-target="#actionsOffcanvas" aria-controls="actionsOffcanvas" title="Actions">
+                                <i class="fas fa-ellipsis-v"></i>
+                            </button>
                         </div>
                     </div>
                     
@@ -2224,6 +2174,31 @@ if ($paste['line_count'] > $maxLines): ?>
         </div>
     </div>
     <?php endif; ?>
+
+    <!-- Offcanvas Actions Menu -->
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="actionsOffcanvas" aria-labelledby="actionsOffcanvasLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="actionsOffcanvasLabel">Actions</h5>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <ul class="list-unstyled">
+                <li><a href="#" class="dropdown-item" onclick="viewRaw()"><i class="fas fa-file-alt me-2"></i>View Raw</a></li>
+                <li><a href="#" class="dropdown-item" onclick="downloadPaste()"><i class="fas fa-download me-2"></i>Download</a></li>
+                <li><a href="#" class="dropdown-item" onclick="sharePaste()"><i class="fas fa-share me-2"></i>Share Paste</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <?php if ($hasFlagged): ?>
+                <li><span class="dropdown-item text-muted disabled"><i class="fas fa-flag me-2"></i>You already reported this paste</span></li>
+                <?php else: ?>
+                <li><a href="#" class="dropdown-item text-danger" onclick="reportPaste('<?php echo $pasteId; ?>')"><i class="fas fa-flag me-2"></i>Report Paste</a></li>
+                <?php endif; ?>
+                <li><hr class="dropdown-divider"></li>
+                <li><a href="create.php?clone=<?php echo $pasteId; ?>" class="dropdown-item"><i class="fas fa-clone me-2"></i>Clone Paste</a></li>
+                <li><a href="create.php?fork=<?php echo $pasteId; ?>" class="dropdown-item"><i class="fas fa-code-branch me-2"></i>Fork Paste</a></li>
+                <li><a href="#" class="dropdown-item" onclick="addToFavorites()"><i class="far fa-heart me-2"></i>Add to Favorites</a></li>
+            </ul>
+        </div>
+    </div>
 </main>
 
 <?php include '../includes/footer.php'; ?>

--- a/pages/view.php
+++ b/pages/view.php
@@ -667,7 +667,7 @@ include '../includes/header.php';
                             </button>
                             <?php endif; ?>
                             <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" title="More Options">
+                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" title="More Options">
                                     <i class="fas fa-ellipsis-h"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end">
@@ -690,7 +690,7 @@ include '../includes/header.php';
                         <!-- Mobile Action Button -->
                         <div class="d-md-none ms-3">
                             <div class="dropdown">
-                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" title="Actions">
+                                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-container="body" title="Actions">
                                     <i class="fas fa-ellipsis-v"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end">


### PR DESCRIPTION
This pull request introduces changes to improve the user interface and functionality of dropdown menus and action buttons, as well as updates to the CSS z-index values for better layering consistency. The most significant changes include replacing dropdown menus with an offcanvas component for better usability and standardizing z-index values across various elements.


fixes #126 
### UI Enhancements:
* [`pages/view.php`](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L669-L727): Replaced dropdown menus with an offcanvas component for actions, improving usability on both desktop and mobile views. Added the new offcanvas structure with corresponding buttons and action items. [[1]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5L669-L727) [[2]](diffhunk://#diff-8a9750b4e3785e1a3dae3f1da6051b1250357b6e27772b06b96a51196ddeb8b5R2177-R2201)

### CSS Improvements:
* [`assets/css/style.css`](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL1087-R1087): Standardized z-index values across dropdown and related elements to `1070` for consistent layering and positioning. This change affects multiple selectors, including `.dropdown-menu`, `.paste-header .dropdown`, and `.paste-header .dropdown-menu.show`. [[1]](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL1087-R1087) [[2]](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL1132-R1132) [[3]](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL1162-R1162) [[4]](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL1172-R1172) [[5]](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeL2144-R2149)