### PR TITLE
Add clone prefill support

### DIFF
--- a/pages/create.php
+++ b/pages/create.php
@@ -22,6 +22,14 @@ if ($forkOriginalId) {
     $prefill = $stmt->fetchColumn();
 }
 
+// Prefill content when cloning an existing paste
+$cloneId = $_GET['clone'] ?? null;
+if ($cloneId) {
+    $stmt = $pdo->prepare("SELECT content FROM pastes WHERE id = ?");
+    $stmt->execute([$cloneId]);
+    $prefill = $stmt->fetchColumn();
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');


### PR DESCRIPTION
## Summary
- fetch paste content when `clone` query param is provided

## Testing
- `php -l pages/create.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d8ba8288321afe7b59b1211016c