### PR TITLE
Fix clone paste content

### DIFF
--- a/pages/create.php
+++ b/pages/create.php
@@ -22,6 +22,14 @@ if ($forkOriginalId) {
     $prefill = $stmt->fetchColumn();
 }
 
+// Prefill content when cloning an existing paste
+$cloneId = $_GET['clone'] ?? null;
+if ($cloneId) {
+    $stmt = $pdo->prepare("SELECT content FROM pastes WHERE id = ?");
+    $stmt->execute([$cloneId]);
+    $prefill = $stmt->fetchColumn();
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');


### PR DESCRIPTION
This pull request adds functionality to prefill the content field when cloning an existing paste. The change introduces logic to fetch the content of a paste by its ID and prefill the form accordingly.

* [`pages/create.php`](diffhunk://#diff-715337185ce3cee7c2585ef186c21a3b802e7025439f2bab298bcfad593db69cR25-R32): Added a block of code to handle cloning pastes by retrieving the content of the specified paste ID (`cloneId`) from the database and assigning it to the `$prefill` variable.