### PR TITLE
Feature paste tags input display

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -117,7 +117,7 @@ function createPaste($title, $content, $language, $expiration = null) {
 /**
  * Create a new paste with advanced features
  */
-function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null, $userId = null) {
+function createPasteAdvanced($title, $content, $language, $expiration = null, $visibility = 'public', $password = null, $burnAfterRead = false, $zeroKnowledge = false, $parentPasteId = null, $userId = null, $tags = '') {
     global $pdo;
     
     $id = generatePasteId();
@@ -152,13 +152,13 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
     }
     
     try {
-        $stmt = $pdo->prepare("
-            INSERT INTO pastes (
-                id, title, content, language, expire_time, created_at,
+        $stmt = $pdo->prepare(
+            "INSERT INTO pastes (
+                id, title, content, language, expire_time, created_at, tags,
                 is_public, password, burn_after_read, zero_knowledge, creator_token, visibility,
                 parent_paste_id, user_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ");
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        );
         
         $stmt->execute([
             $id,
@@ -167,6 +167,7 @@ function createPasteAdvanced($title, $content, $language, $expiration = null, $v
             $language,
             $expireTime,
             time(), // Unix timestamp
+            $tags,
             $isPublic,
             $password,
             $burnAfterRead ? 1 : 0,

--- a/pages/create.php
+++ b/pages/create.php
@@ -41,6 +41,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $zeroKnowledge = isset($_POST['zero_knowledge']);
     $pasteAsGuest = isset($_POST['paste_as_guest']);
     $parentPasteId = $_POST['parent_paste_id'] ?? null;
+    $tagsInput = trim($_POST['tags'] ?? '');
+    $tags = '';
+    if ($tagsInput !== '') {
+        $tagsArray = array_filter(array_map('trim', explode(',', $tagsInput)));
+        $tags = implode(',', $tagsArray);
+    }
     
     if (empty($content)) {
         $error = 'Content cannot be empty.';
@@ -83,7 +89,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $userId = $_SESSION['user_id'];
         }
 
-        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId, $userId);
+        $result = createPasteAdvanced($title, $content, $language, $expirationDate, $visibility, $hashedPassword, $burnAfterRead, $zeroKnowledge, $parentPasteId, $userId, $tags);
         
         if ($result) {
             // Handle different return formats for compatibility
@@ -240,6 +246,17 @@ include '../includes/header.php';
                                         <option value="shell">Shell</option>
                                         <option value="dockerfile">Dockerfile</option>
                                     </select>
+                                </div>
+
+                                <!-- Tags -->
+                                <div class="mb-3">
+                                    <label for="tags" class="form-label">
+                                        <i class="fas fa-tags me-1"></i>Tags
+                                    </label>
+                                    <input type="text" class="form-control" id="tags" name="tags"
+                                           placeholder="e.g. php, security, snippet"
+                                           value="<?php echo htmlspecialchars($_POST['tags'] ?? ''); ?>">
+                                    <div class="form-text">Separate tags with commas</div>
                                 </div>
 
                                 <!-- Content -->


### PR DESCRIPTION
This pull request introduces a new feature to support tags for pastes, allowing users to classify and organize their pastes with comma-separated keywords. Changes include updates to the database schema, backend logic, and the frontend form to accommodate this functionality.

### Backend changes:

* `includes/db.php`: 
  - Added a `$tags` parameter to the `createPasteAdvanced` function.
  - Updated the SQL query in `createPasteAdvanced` to insert the `tags` field into the database.
  - Included `$tags` in the `execute` array for database insertion.

### Frontend changes:

* `pages/create.php`:
  - Added logic to process user input for tags, including trimming whitespace and filtering empty values.
  - Passed the processed `$tags` variable to the `createPasteAdvanced` function when creating a new paste.
  - Added a new input field in the paste creation form for users to specify tags, with instructions on how to format them.